### PR TITLE
[FIX] Issue with customer doctype not allowing name series past 10

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -53,7 +53,7 @@ class Customer(TransactionBase):
 
 	def get_customer_name(self):
 		if frappe.db.get_value("Customer", self.customer_name):
-			count = frappe.db.sql("""select ifnull(max(SUBSTRING_INDEX(name, ' ', -1)), 0) from tabCustomer
+			count = frappe.db.sql("""select ifnull(MAX(CAST(SUBSTRING_INDEX(name, ' ', -1) AS UNSIGNED)), 0) from tabCustomer
 				 where name like %s""", "%{0} - %".format(self.customer_name), as_list=1)[0][0]
 			count = cint(count) + 1
 			return "{0} - {1}".format(self.customer_name, cstr(count))


### PR DESCRIPTION
Query used to fetch mast number in series breaks due to sql MAX function handing string and number ordering differently. This causes the last "[name] - 9" series to be picked up as last in the series instead of "[name] - 10". Fix is to cast value to unsigned to MAX handles ordering correctly.
