### PR TITLE
Hotfix contract sign validation

### DIFF
--- a/erpnext/templates/pages/contract_detail.html
+++ b/erpnext/templates/pages/contract_detail.html
@@ -13,7 +13,31 @@
 
 	<script>
 		frappe.ready(function () {
-			$("#agree-contract").on("click", function () {
+			var $termsBox = $("#contract-terms");
+			var $agreeBtn = $("#agree-contract");
+			var $signeeName = $("#contract-signee");
+
+			function validateContractSigning() {
+				var isScrollVisible = $termsBox.get(0).scrollHeight > $termsBox.get(0).clientHeight;
+				var isScrolledToBottom = $termsBox.get(0).scrollHeight - $termsBox.scrollTop() < $termsBox.outerHeight();
+				var nameSigned = $signeeName.val();
+
+				var isValid = ( ( isScrollVisible && isScrolledToBottom ) || !isScrollVisible ) && (nameSigned && nameSigned.length > 3);
+				if ( isValid ) {
+					$agreeBtn.removeClass("disabled");
+				} else {
+					$agreeBtn.addClass("disabled");
+				}
+
+				return isValid;
+			}
+
+			$agreeBtn.on("click", function () {
+
+				if ( !validateContractSigning() ) {
+					return;
+				}
+
 				frappe.call({
 					method: "erpnext.crm.doctype.contract.contract.accept_contract_terms",
 					args: {
@@ -29,11 +53,12 @@
 					}
 				})
 			});
-			$("#contract-terms").bind("scroll", function (e) {
-				var elem = $(e.currentTarget);
-				if (elem[0].scrollHeight - elem.scrollTop() < elem.outerHeight()) {
-					$("#agree-contract").removeClass("disabled");
-				}
+			$signeeName.on("change keyup", function() {
+				validateContractSigning();
+			});
+
+			$termsBox.bind("scroll", function (e) {
+				validateContractSigning();
 			});
 		});
 	</script>


### PR DESCRIPTION
- Adds signer field validation.
- Fixes contract scroll blocking validation to include short contracts.
- Clean up validation to be done in one place.
- Blocks agree button click if validation isn't passed.

![contract-validation-scroll](https://user-images.githubusercontent.com/1656249/39532791-84a524f6-4dfb-11e8-8f1c-38b4907e24a2.gif)
