### PR TITLE
Adds a hook to calculate_taxes_and_totals on account controller

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -114,9 +114,8 @@ class AccountsController(TransactionBase):
 		calculate_taxes_and_totals(self)
 
 		hooks = frappe.get_hooks("on_calculate_taxes_and_totals") or []
-		if hooks:
-			for method in hooks:
-				frappe.call(method, doc=self)
+		for method in hooks:
+			frappe.call(method, doc=self)
 
 		if self.doctype in ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"]:
 			self.calculate_commission()

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -113,6 +113,11 @@ class AccountsController(TransactionBase):
 		from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
 		calculate_taxes_and_totals(self)
 
+		hooks = frappe.get_hooks("on_calculate_taxes_and_totals") or []
+		if hooks:
+			for method in hooks:
+				frappe.call(method, doc=self)
+
 		if self.doctype in ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"]:
 			self.calculate_commission()
 			self.calculate_contribution()


### PR DESCRIPTION
Can't see a way around extending this to allow for our coupon calcs to work.
It does allow us to clean up other code that relied on tricks to get things working with totals.