### PR TITLE
Remove uri encoding from search results

### DIFF
--- a/erpnext/templates/pages/product_search.html
+++ b/erpnext/templates/pages/product_search.html
@@ -10,7 +10,7 @@
 <script>
 frappe.ready(function() {
 	var txt = frappe.utils.get_url_arg("search");
-	$(".search-results").html("{{ _('Search results for') }}: " + txt);
+	$(".search-results").html('{{ _("Search results for") + ": " + html2text(frappe.form_dict.search or "")|trim }}');
 	window.search = txt;
 	window.start = 0;
 	window.get_product_list();

--- a/erpnext/templates/pages/product_search.html
+++ b/erpnext/templates/pages/product_search.html
@@ -10,7 +10,7 @@
 <script>
 frappe.ready(function() {
 	var txt = frappe.utils.get_url_arg("search");
-	$(".search-results").html("{{ _('Search results for') }}: " + encodeURIComponent(txt));
+	$(".search-results").html("{{ _('Search results for') }}: " + txt);
 	window.search = txt;
 	window.start = 0;
 	window.get_product_list();


### PR DESCRIPTION
Issue: The search strings on the website were encoded and displayed, for example, maple "leaf", displayed as maple%20%22leaf%22
![image](https://user-images.githubusercontent.com/8912289/40650602-4f786214-6351-11e8-95f8-767ccc22cf6e.png)

Solution: Remove uri encoding form search string.
![image](https://user-images.githubusercontent.com/8912289/40650688-81414a90-6351-11e8-80dc-74b28effbd30.png)

Related to: [https://github.com/frappe/frappe/pull/5626](https://github.com/frappe/frappe/pull/5626
)
