### PR TITLE
Validate response message for frappe call

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -236,7 +236,7 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 				items: my_items
 			},
 			callback: function(r) {
-				if(r.exc) return;
+				if(r.exc || !r.message) return;
 
 				var i = 0;
 				var item_length = cur_frm.doc.items.length;


### PR DESCRIPTION
If the response is empty on clicking Link to Material Request in Request for Quotation, there was a console error Unable to handle success response. So added a check to see if r.message exists or not before accessing it.