### PR TITLE
Add new print format for Packing Slip

### DIFF
--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -73,13 +73,13 @@ cur_frm.cscript.validate_calculate_item_details = function(doc) {
 // Also check for 0 qty
 cur_frm.cscript.validate_duplicate_items = function(doc, ps_detail) {
 	for(var i=0; i<ps_detail.length; i++) {
-		for(var j=0; j<ps_detail.length; j++) {
-			if(i!=j && ps_detail[i].item_code && ps_detail[i].item_code==ps_detail[j].item_code) {
-				frappe.msgprint(__("You have entered duplicate items. Please rectify and try again."));
-				frappe.validated = false;
-				return;
-			}
-		}
+		// for(var j=0; j<ps_detail.length; j++) {
+		// 	if(i!=j && ps_detail[i].item_code && ps_detail[i].item_code==ps_detail[j].item_code) {
+		// 		frappe.msgprint(__("You have entered duplicate items. Please rectify and try again."));
+		// 		frappe.validated = false;
+		// 		return;
+		// 	}
+		// }
 		if(flt(ps_detail[i].qty)<=0) {
 			frappe.msgprint(__("Invalid quantity specified for item {0}. Quantity should be greater than 0.", [ps_detail[i].item_code]));
 			frappe.validated = false;


### PR DESCRIPTION
Depends on https://github.com/DigiThinkIT/jhaudio_customizations/pull/1171

<hr>

**Changes:**
- Remove JS validation code for duplicate items (currently, Packing Slip doesn't deal with serialized items, and expects all the items to be clubbed together)
- Update SQL query to separate out individual items for view; each item line also shows it's corresponding IEM Owner.

**Screenshots:**

![image](https://user-images.githubusercontent.com/13396535/46869625-0ca76980-ce4a-11e8-983d-12f169098e4d.png)
![image](https://user-images.githubusercontent.com/13396535/46869626-0e712d00-ce4a-11e8-90b4-aee475cff4fa.png)