### PR TITLE
Validations for multiple trip records for the same driver or Delivery Note

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -66,6 +66,49 @@ frappe.ui.form.on('Delivery Trip', {
 		}
 	},
 
+	validate: function (frm) {
+		if (frm.doc.delivery_stops) {
+			frappe.call({
+				method: "erpnext.stock.doctype.delivery_trip.delivery_trip.validate_unique_delivery_notes",
+				args: {
+					delivery_stops: frm.doc.delivery_stops
+				},
+				async: false,
+				freeze: false,
+				freeze_message: "Test",
+				callback: function (r) {
+					if (r) {
+						let confirm_message = `The entered Delivery Notes already exist in the following
+												Delivery Trips: ${r.message.join(", ")}. Do you want to
+												continue?`;
+
+						frappe.confirm(__(confirm_message), function () {
+							return;
+						});
+					};
+				}
+			});
+		};
+	},
+
+	driver: function (frm) {
+		if (frm.doc.driver) {
+			frappe.db.get_value("Delivery Trip", {
+				driver: frm.doc.driver,
+				departure_time: [">", frappe.datetime.nowdate()]
+			}, "name", (r) => {
+				if (r) {
+					let confirm_message = `${frm.doc.driver_name} has already been assigned a Delivery Trip
+											today (${r.name}). Do you want to modify that instead?`;
+
+					frappe.confirm(__(confirm_message), function () {
+						frappe.set_route("Form", "Delivery Trip", r.name);
+					});
+				};
+			});
+		};
+	},
+
 	calculate_arrival_time: function (frm) {
 		frappe.db.get_value("Google Maps Settings", { name: "Google Maps Settings" }, "enabled", (r) => {
 			if (r.enabled == 0) {

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -84,13 +84,15 @@ frappe.ui.form.on('Delivery Trip', {
 
 						frappe.confirm(
 							__(confirm_message),
-							() => resolve(),  // If "Yes" is selected
-							() => frappe.set_route("List", frm.doc.doctype)  // If "No" is selected
+							() => { return resolve(); },  // If "Yes" is selected
+							() => { frappe.set_route("List", frm.doc.doctype); }  // If "No" is selected
 						);
-					} else { resolve(); };
+					} else { return resolve(); }
+				}).fail((err) => {
+					return reject(err);
 				});
 			})
-		};
+		}
 	},
 
 	driver: function (frm) {

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -75,22 +75,22 @@ frappe.ui.form.on('Delivery Trip', {
 					method: "erpnext.stock.doctype.delivery_trip.delivery_trip.validate_unique_delivery_notes",
 					args: {
 						delivery_stops: frm.doc.delivery_stops
-					}
-				}).then((r) => {
-					if (r.message.length) {
-						let confirm_message = `Atleast one of the entered Delivery Notes already exist in
-											the following Delivery Trips: ${r.message.join(", ")}.
-											Do you still want to continue?`;
+					},
+					callback: (r) => {
+						if (r.message.length) {
+							let confirm_message = `Atleast one of the entered Delivery Notes already exist in
+												the following Delivery Trips: ${r.message.join(", ")}.
+												Do you still want to continue?`;
 
-						frappe.confirm(
-							__(confirm_message),
-							() => { return resolve(); },  // If "Yes" is selected
-							() => { frappe.set_route("List", frm.doc.doctype); }  // If "No" is selected
-						);
-					} else { return resolve(); }
-				}).fail((err) => {
-					return reject(err);
-				});
+							frappe.confirm(
+								__(confirm_message),
+								() => { resolve(); },  // If "Yes" is selected
+								() => { frappe.set_route("List", frm.doc.doctype); }  // If "No" is selected
+							);
+						} else { resolve(); }
+					},
+					error: (r) => reject(r.message)
+				})
 			})
 		}
 	},

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -94,7 +94,7 @@ class DeliveryTrip(Document):
 			note_doc.save()
 
 		delivery_notes = [get_link_to_form("Delivery Note", note) for note in delivery_notes]
-		frappe.msgprint(_("Delivery Notes {0} updated".format(", ".join(delivery_notes))))
+		frappe.msgprint(_("Delivery Notes {0} updated".format(", ".join(delivery_notes))), alert=True)
 
 	def process_route(self, optimize):
 		"""
@@ -353,13 +353,14 @@ def get_directions(route, optimize):
 @frappe.whitelist()
 def validate_unique_delivery_notes(delivery_stops):
 	delivery_stops = json.loads(delivery_stops)
-	delivery_notes = [stop["delivery_note"] for stop in delivery_stops if stop["delivery_note"]]
+	delivery_notes = [stop.get("delivery_note") for stop in delivery_stops if stop.get("delivery_note")]
 
 	if not delivery_notes:
 		return []
 
 	existing_trips = frappe.get_all("Delivery Stop",
-									filters={"delivery_note": ["IN", delivery_notes]},
+									filters={"delivery_note": ["IN", delivery_notes],
+											"docstatus": ["<", 2]},
 									fields=["distinct(parent)"])
 	existing_trips = [stop.parent for stop in existing_trips]
 


### PR DESCRIPTION
Changes:
- Whenever a Delivery Trip is created, from whichever source, and the user enters the driver, the system checks for trips today for that driver, and if one is found, asks the user if they want to modify the old one, or continue with the new one.
  - **Caveat**: If the old trip is submitted, the only way to proceed with it would be to cancel-amend the document. Do we want users to be able to add stops to submitted trips?
- Whenever a Delivery Trip is created with stops, and if some/all of the Delivery Notes have already been added in another trip, then the system adds a prompt asking if they want to continue with the added Delivery Note.

<details>
<summary>Screenshots / GIFs</summary>

Creating a Delivery Trip for a driver with an existing trip on the same day.
- Clicking on **Yes** will take the user to the existing Delivery Trip.
- Clicking on **No** will let the user continue as normal.

![multi-driver-dt](https://user-images.githubusercontent.com/13396535/47360910-4439cf80-d6ee-11e8-921c-61f08f625a18.gif)

<hr>

Creating a Delivery Trip with Delivery Notes that are already present in other trips.
- Clicking on **Yes** will let the user continue as normal.
- Clicking on **No** will delete the new document and go back to the listview.

![multi-dn-dt-1](https://user-images.githubusercontent.com/13396535/47413816-f1fbbb80-d78c-11e8-9b48-2cce0ef8c819.gif)

</details>