### PR TITLE
Fix error when trying to convert a task into a group even if no child tasks exist

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -80,15 +80,15 @@ frappe.ui.form.on("Task", {
 		}
 	},
 
-	is_group: function(frm) {
+	is_group: function (frm) {
 		frappe.call({
-			method:"erpnext.projects.doctype.task.task.check_if_child_exists",
+			method: "erpnext.projects.doctype.task.task.check_if_child_exists",
 			args: {
 				name: frm.doc.name
 			},
-			callback: function(r){
-				if(r.message){
-					frappe.msgprint(__('Cannot convert it to non-group. Child Tasks exist.'));
+			callback: function (r) {
+				if (r.message.length > 0) {
+					frappe.msgprint(__(`Cannot convert it to non-group. The following child Tasks exist: ${r.message.join(", ")}.`));
 					frm.reload_doc();
 				}
 			}

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -2,11 +2,14 @@
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
-import frappe, json
 
-from frappe.utils import getdate, date_diff, add_days, cstr
+import json
+
+import frappe
 from frappe import _, throw
+from frappe.utils import add_days, cstr, date_diff, get_link_to_form, getdate
 from frappe.utils.nestedset import NestedSet
+
 
 class CircularReferenceError(frappe.ValidationError): pass
 
@@ -157,8 +160,10 @@ class Task(NestedSet):
 
 @frappe.whitelist()
 def check_if_child_exists(name):
-	return frappe.db.sql("""select name from `tabTask`
-		where parent_task = %s""", name)
+	child_tasks = frappe.get_all("Task", filters={"parent_task": name})
+	child_tasks = [get_link_to_form("Task", task.name) for task in child_tasks]
+	return child_tasks
+
 
 def get_project(doctype, txt, searchfield, start, page_len, filters):
 	from erpnext.controllers.queries import get_match_cond


### PR DESCRIPTION
**Problem:**

If you try to make any Task into a Parent Task, the system would throw an error, saying that Child Tasks exist, even though there are none.

**Cause:**

When the call to check if child tasks exist is made, and no tasks are found, it returns an empty object, which passes the Boolean check in JavaScript, and throws the error.

**Solution:**

Improve the error validation, and also give more information for legitimate errors.