### PR TITLE
fix(returns): Fix error that didn't allow return of delivered items

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -446,8 +446,8 @@ def make_sales_invoice(source_name, target_doc=None):
 			target.update(get_fetch_values("Sales Invoice", 'company_address', target.company_address))
 
 	def update_item(source_doc, target_doc, source_parent):
-		target_doc.qty = (source_doc.qty -
-			invoiced_qty_map.get(source_doc.name, 0) - returned_qty_map.get(source_doc.so_detail, 0))
+		returned_qty = returned_qty_map.get(source_doc.so_detail, 0) if not source_parent.is_return else 0
+		target_doc.qty = (source_doc.qty - invoiced_qty_map.get(source_doc.name, 0) - returned_qty)
 
 		if source_doc.serial_no and source_parent.per_billed > 0:
 			target_doc.serial_no = get_delivery_note_serial_no(source_doc.item_code,


### PR DESCRIPTION
**Problem:**

A [recent change upstream](https://github.com/frappe/erpnext/commit/7ec5e80b707444bc1b8a2664bdfc71ee402d0677#diff-46bfd3824b5644cfbd97610d95384222) changed the logic of how Return Invoices are processed. Initially, the system wasn't considering the returned quantities while making the invoice. That change fixed the issue.

However, due to this change, whenever you tried to record a return, the Return Invoice would consider the newly created Delivery Note in its item qty calculation, and thinks that the returned quantities were double their actual returned quantity, thereby throwing that error.

<details>

<summary> Traceback </summary>

```diff
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 848, in submit
    self._submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 837, in _submit
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 908, in run_post_save_methods
    self.run_method("on_submit")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/delivery_note/delivery_note.py", line 223, in on_submit
    self.make_return_invoice()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/delivery_note/delivery_note.py", line 343, in make_return_invoice
    return_invoice.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 222, in insert
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 74, in validate
    super(SalesInvoice, self).validate()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/selling_controller.py", line 39, in validate
    super(SellingController, self).validate()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 20, in validate
    super(StockController, self).validate()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py", line 75, in validate
    validate_return(self)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/sales_and_purchase_return.py", line 17, in validate_return
    validate_returned_items(doc)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/sales_and_purchase_return.py", line 83, in validate_returned_items
    validate_quantity(doc, d, ref, valid_items, already_returned_items)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/sales_and_purchase_return.py", line 140, in validate_quantity
    .format(args.idx, max_returnable_qty, args.item_code), StockOverReturnError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 345, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 331, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 304, in _raise_exception
    raise raise_exception(msg)
StockOverReturnError: Row # 1: Cannot return more than 10.0 for Item TEST-ITEM
```
</details>