### PR TITLE
fix(batch_select): Allow batches to be updated with more quantity in the select dialog

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -93,11 +93,11 @@ frappe.ui.form.on('Stock Entry', {
 	},
 
 	refresh: function(frm) {
-		frm.add_custom_button(__('Select Item Batches'), () => {
-			frm.trigger("select_batch_no");
-		});
-
 		if(!frm.doc.docstatus) {
+			frm.add_custom_button(__('Select Item Batches'), () => {
+				frm.trigger("select_batch_no");
+			});
+
 			frm.trigger('validate_purpose_consumption');
 			frm.add_custom_button(__('Make Material Request'), function() {
 				frappe.model.with_doctype('Material Request', function() {
@@ -286,6 +286,7 @@ frappe.ui.form.on('Stock Entry', {
 										label: __('Quantity'),
 										fieldtype: 'Read Only',
 										fieldname: 'qty',
+										in_list_view: 1
 									},
 									{
 										label: __('Batch No'),
@@ -298,6 +299,7 @@ frappe.ui.form.on('Stock Entry', {
 												filters: {
 													item: doc.item_code,
 													s_warehouse: doc.s_warehouse,
+													t_warehouse: doc.t_warehouse,
 													qty: doc.qty
 												}
 											};

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1337,4 +1337,6 @@ def validate_sample_quantity(item_code, sample_quantity, qty, batch_no = None):
 
 @frappe.whitelist()
 def get_available_batches_in_warehouse(doctype, txt, searchfield, start, page_len, filters):
-	return get_batches(filters.get("item"), filters.get("s_warehouse"), filters.get("qty"), as_dict=False)
+	warehouse = filters.get("t_warehouse") or filters.get("s_warehouse")
+
+	return get_batches(filters.get("item"), warehouse, filters.get("qty"), as_dict=False)


### PR DESCRIPTION
**Problem:**

The Batch Select dialog was allowing users to select existing batches for consumption, but wasn't allowing manufactured items to go into existing batches. This PR adds the functionality to do so.

**GIF:**

![auto-select-batches](https://user-images.githubusercontent.com/13396535/52043547-027ab980-2566-11e9-87eb-a65899d71520.gif)