### PR TITLE
fix: Pick field value instead of field name for update

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -316,13 +316,12 @@ class StatusUpdater(Document):
 
 			# Update the status field
 			if args.get('status_field'):
-				if args.get("target_parent_field") < 0.001:
+				target_parent_field_value = frappe.db.get_value(args.get("target_parent_dt"), args.get("name"), args.get("target_parent_field"))
+
+				if target_parent_field_value < 0.001:
 					status = 'Not '
 				else:
-					if args.get("target_parent_field") >= 99.999999:
-						status = 'Fully '
-					else:
-						status = 'Partly '
+					status = 'Fully ' if target_parent_field_value >= 99.999999 else 'Partly '
 
 				status += args.get("keyword")
 				frappe.db.set_value(args.get("target_parent_dt"), args.get("name"), args.get("status_field"), status, update_modified=update_modified)


### PR DESCRIPTION
**Problem:**

On cancelling a DN and SI, the status in the SO wouldn't properly update because it would pick up the fieldname instead of the field value. This fixes it.