### PR TITLE
fix(stock): Update batch quantity whenever stock in it is moved

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -116,7 +116,7 @@ class Batch(Document):
 			frappe.throw(_("The selected item cannot have Batch"))
 
 	def calculate_batch_qty(self):
-		self.batch_qty = frappe.db.get_value("Stock Ledger Entry", {"batch_no": self.batch_id}, "sum(actual_qty)")
+		self.batch_qty = frappe.db.get_value("Stock Ledger Entry", {"docstatus": 1, "batch_no": self.batch_id}, "sum(actual_qty)")
 
 	def before_save(self):
 		has_expiry_date, shelf_life_in_days = frappe.db.get_value('Item', self.item, ['has_expiry_date', 'shelf_life_in_days'])

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -31,6 +31,11 @@ class StockLedgerEntry(Document):
 		self.check_stock_frozen_date()
 		self.actual_amt_check()
 
+		if self.batch_no:
+			batch = frappe.get_doc("Batch", self.batch_no)
+			batch.calculate_batch_qty()
+			batch.save()
+
 		if not self.get("via_landed_cost_voucher") and self.voucher_type != 'Stock Reconciliation':
 			from erpnext.stock.doctype.serial_no.serial_no import process_serial_no
 			process_serial_no(self)
@@ -132,4 +137,3 @@ def on_doctype_update():
 
 	frappe.db.add_index("Stock Ledger Entry", ["voucher_no", "voucher_type"])
 	frappe.db.add_index("Stock Ledger Entry", ["batch_no", "item_code", "warehouse"])
-


### PR DESCRIPTION
**Problem:**

Batches would not update their batch quantity whenever a Stock Entry was made for that Batch. The only time it updates is when the Batch is saved.

**Solution:**

Whenever a Stock Ledger Entry is made, and it has a linked Batch, update the batch quantity.

