### PR TITLE
fix(stock): Allow expired batches to be flushed out of the system

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1105,7 +1105,7 @@ class StockEntry(StockController):
 						frappe.MappingMismatchError)
 
 	def validate_batch(self):
-		if self.purpose in ["Material Transfer for Manufacture", "Manufacture", "Repack", "Subcontract", "Material Issue"]:
+		if self.purpose in ["Material Transfer for Manufacture", "Manufacture", "Repack", "Subcontract"]:
 			for item in self.get("items"):
 				if item.batch_no:
 					disabled = frappe.db.get_value("Batch", item.batch_no, "disabled")


### PR DESCRIPTION
Made upstream to [hotfix](https://github.com/frappe/erpnext/pull/17477) and [develop](https://github.com/frappe/erpnext/pull/17478).

**Problem:**

Trying to issue batches out of the system fails for expired batches because of an extra validation.

**Solution:**

Remove validation for Material Issue stock entries.