### PR TITLE
fix(projects): Remove hardcode of expected end date for new Tasks

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -26,23 +26,17 @@ frappe.ui.form.on("Task", {
 				}
 			}
 		}
-		if(!frm.is_group){
-			var doc = frm.doc;
-			if(doc.__islocal) {
-				if(!frm.doc.exp_end_date) {
-					frm.set_value("exp_end_date", frappe.datetime.add_days(new Date(), 7));
-				}
-			}
 
-			if(!doc.__islocal) {
-				if(frm.perm[0].write) {
-					if(frm.doc.status!=="Closed" && frm.doc.status!=="Cancelled") {
-						frm.add_custom_button(__("Close"), function() {
+		if(!frm.doc.is_group){
+			if (!frm.is_new()) {
+				if (frm.perm[0].write) {
+					if (!["Closed", "Cancelled"].includes(frm.doc.status)) {
+						frm.add_custom_button(__("Close"), () => {
 							frm.set_value("status", "Closed");
 							frm.save();
 						});
 					} else {
-						frm.add_custom_button(__("Reopen"), function() {
+						frm.add_custom_button(__("Reopen"), () => {
 							frm.set_value("status", "Open");
 							frm.save();
 						});


### PR DESCRIPTION
**Ref:** [TASK-2019-00276](https://digithinkit.global/desk#Form/Task/TASK-2019-00276)

<hr>

**Problem:**
Whenever a new Task is created, the system adds a hardcoded number of days to the current date and sets it as the expected end date. This can be un-intuitive when it comes to managing projects, since a lot of Tasks may have differing completion times.

**Solution:**
Remove the hardcode, and let the user select the expected end date for each Task manually based on its scope.

<hr>

**Screenshots / GIFs:**

![exp-end-date](https://user-images.githubusercontent.com/13396535/58242670-db423500-7d6c-11e9-987c-29db21901573.gif)