### PR TITLE
fix(patch): remove bad patch reference

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -595,7 +595,6 @@ erpnext.patches.v11_0.make_italian_localization_fields # 26-03-2019
 erpnext.patches.v11_1.make_job_card_time_logs
 erpnext.patches.v11_1.set_variant_based_on
 erpnext.patches.v12_0.set_total_batch_quantity
-erpnext.patches.v11_1.set_salary_details_submitable
 erpnext.patches.v11_1.move_customer_lead_to_dynamic_column
 erpnext.patches.v11_1.woocommerce_set_creation_user
 erpnext.patches.v11_1.set_default_action_for_quality_inspection


### PR DESCRIPTION
There was a typo in one of ERPNext's commits, during a merge conflict, I didn't notice it.