### PR TITLE
fix: ignore_workstation_time_overlap actually ignores time overlaps

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -23,10 +23,11 @@ class JobCard(Document):
 				if get_datetime(d.from_time) > get_datetime(d.to_time):
 					frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
 
-				data = self.get_overlap_for(d)
-				if data:
-					frappe.throw(_("Row {0}: From Time and To Time of {1} is overlapping with {2}")
-						.format(d.idx, self.name, data.name))
+				if not frappe.db.get_single_value("Projects Settings", "ignore_workstation_time_overlap"):
+					data = self.get_overlap_for(d)
+					if data:
+						frappe.throw(_("Row {0}: From Time and To Time of {1} is overlapping with {2}")
+							.format(d.idx, self.name, data.name))
 
 				if d.from_time and d.to_time:
 					d.time_in_mins = time_diff_in_hours(d.to_time, d.from_time) * 60


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

