### PR TITLE
fix(Delivery Note): change the text Invoice from make button on delivery note to be Sales Invoice

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -171,7 +171,7 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 			});
 
 			if(!from_sales_invoice) {
-				this.frm.add_custom_button(__('Invoice'), function() { me.make_sales_invoice() },
+				this.frm.add_custom_button(__('Sales Invoice'), function() { me.make_sales_invoice() },
 					__("Make"));
 			}
 		}


### PR DESCRIPTION
**Task:** [TASK-2019-00537](https://digithinkit.global/desk#Form/Task/TASK-2019-00537)

**Screenshots/Gifs:**

![Screenshot from 2019-08-02 19-07-08](https://user-images.githubusercontent.com/13060550/62374123-dbbf2f00-b558-11e9-9bdc-772e748dae2e.png)
