### PR TITLE
fix: error while trying to get directions

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -349,7 +349,7 @@ def get_directions(route, optimize):
 	try:
 		directions = maps_client.directions(**directions_data)
 	except Exception as e:
-		frappe.throw(_(e.message))
+		frappe.throw(_(e))
 
 	return directions[0] if directions else False
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/home/rohan/weed/env/local/lib/python3.6/site-packages/rq/worker.py", line 793, in perform_job
    rv = job.perform()
  File "/home/rohan/weed/env/local/lib/python3.6/site-packages/rq/job.py", line 599, in perform
    self._result = self._execute()
  File "/home/rohan/weed/env/local/lib/python3.6/site-packages/rq/job.py", line 605, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/home/rohan/weed/apps/frappe/frappe/utils/background_jobs.py", line 103, in execute_job
    method(**kwargs)
  File "/home/rohan/weed/apps/bloomstack_demo/bloomstack_demo/demo.py", line 47, in simulate_for_one_day
    simulate(1)
  File "/home/rohan/weed/apps/bloomstack_demo/bloomstack_demo/demo.py", line 155, in simulate
    make_delivery_trips(delivery_notes, drivers, vehicles)
  File "/home/rohan/weed/apps/bloomstack_demo/bloomstack_demo/demo.py", line 952, in make_delivery_trips
    delivery_trip.process_route(optimize=True)
  File "/home/rohan/weed/apps/erpnext/erpnext/stock/doctype/delivery_trip/delivery_trip.py", line 121, in process_route
    directions = get_directions(route, optimize)
  File "/home/rohan/weed/apps/erpnext/erpnext/stock/doctype/delivery_trip/delivery_trip.py", line 352, in get_directions
    frappe.throw(_(e.message))
AttributeError: 'TransportError' object has no attribute 'message'
```