### PR TITLE
fix: prioritize empty over expired as batch status

### DIFF
--- a/erpnext/stock/doctype/batch/batch_list.js
+++ b/erpnext/stock/doctype/batch/batch_list.js
@@ -3,10 +3,10 @@ frappe.listview_settings['Batch'] = {
 	get_indicator: (doc) => {
 		if (doc.disabled) {
 			return [__("Disabled"), "darkgrey", "disabled,=,1"];
-		} else if (doc.expiry_date && frappe.datetime.get_diff(doc.expiry_date, frappe.datetime.nowdate()) <= 0) {
-			return [__("Expired"), "red", "expiry_date,not in,|expiry_date,<=,Today|batch_qty,>,0|disabled,=,0"]
 		} else if (!doc.batch_qty) {
 			return [__("Empty"), "darkgrey", "batch_qty,=,0|disabled,=,0"];
+		} else if (doc.expiry_date && frappe.datetime.get_diff(doc.expiry_date, frappe.datetime.nowdate()) <= 0) {
+			return [__("Expired"), "red", "expiry_date,not in,|expiry_date,<=,Today|batch_qty,>,0|disabled,=,0"]
 		} else {
 			return [__("Active"), "green", "batch_qty,>,0|disabled,=,0"];
 		};


### PR DESCRIPTION
**Problem:**

If a batch is expired, but is empty, the list view still shows the batch as Expired.