### PR TITLE
fix: pull actual transferred qty for manufacture

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -930,89 +930,86 @@ class StockEntry(StockController):
 				})
 
 	def get_transfered_raw_materials(self):
-		transferred_materials = frappe.db.sql("""
-			select
-				item_name, original_item, item_code, sum(qty) as qty, sed.t_warehouse as warehouse,
-				description, stock_uom, expense_account, cost_center
-			from `tabStock Entry` se,`tabStock Entry Detail` sed
-			where
-				se.name = sed.parent and se.docstatus=1 and se.purpose='Material Transfer for Manufacture'
-				and se.work_order= %s and ifnull(sed.t_warehouse, '') != ''
-			group by sed.item_code, sed.t_warehouse
-		""", self.work_order, as_dict=1)
+		qty_to_manufacture, produced_qty = frappe.db.get_value("Work Order", self.work_order, ["qty", "produced_qty"])
+		qty_to_manufacture = flt(qty_to_manufacture)
+		produced_qty = flt(produced_qty)
+		remaining_qty = qty_to_manufacture - produced_qty
 
-		materials_already_backflushed = frappe.db.sql("""
-			select
-				item_code, sed.s_warehouse as warehouse, sum(qty) as qty
-			from
-				`tabStock Entry` se, `tabStock Entry Detail` sed
-			where
-				se.name = sed.parent and se.docstatus=1
-				and (se.purpose='Manufacture' or se.purpose='Material Consumption for Manufacture')
-				and se.work_order= %s and ifnull(sed.s_warehouse, '') != ''
-			group by sed.item_code, sed.s_warehouse
-		""", self.work_order, as_dict=1)
+		query = """
+			SELECT
+				sed.item_name,
+				sed.original_item,
+				sed.item_code,
+				sum(sed.qty) AS qty,
+				sed.t_warehouse AS warehouse,
+				sed.description,
+				sed.stock_uom,
+				sed.expense_account,
+				sed.cost_center
+			FROM
+				`tabStock Entry` se,
+				`tabStock Entry Detail` sed
+			WHERE
+				se.name = sed.parent
+					AND se.docstatus = 1
+					AND se.purpose in %s
+					AND se.work_order = %s
+					AND ifnull(sed.t_warehouse, '') != ''
+			GROUP BY
+				sed.item_code,
+				sed.t_warehouse
+		"""
 
-		backflushed_materials= {}
-		for d in materials_already_backflushed:
-			backflushed_materials.setdefault(d.item_code,[]).append({d.warehouse: d.qty})
+		# get all items already consumed for manufacture against the work order
+		consumed_materials = frappe.db.sql(query, self.work_order, ['Manufacture', 'Material Consumption for Manufacture'], as_dict=1)
+		backflushed_materials = {}
+		for item in consumed_materials:
+			backflushed_materials.setdefault(item.item_code, []).append({item.warehouse: item.qty})
 
-		po_qty = frappe.db.sql("""select qty, produced_qty, material_transferred_for_manufacturing from
-			`tabWork Order` where name=%s""", self.work_order, as_dict=1)[0]
-
-		manufacturing_qty = flt(po_qty.qty)
-		produced_qty = flt(po_qty.produced_qty)
-		trans_qty = flt(po_qty.material_transferred_for_manufacturing)
-
+		# loop through the transferred quantities, and add an entry for each
+		# remaining item needed for manufacture, if not already consumed
+		transferred_materials = frappe.db.sql(query, self.work_order, ['Material Transfer for Manufacture'], as_dict=1)
 		for item in transferred_materials:
-			qty= item.qty
+			item_qty = item.qty
 			item_code = item.original_item or item.item_code
 			req_items = frappe.get_all('Work Order Item',
 				filters={'parent': self.work_order, 'item_code': item_code},
-				fields=["required_qty", "consumed_qty"]
-				)
+				fields=["required_qty", "consumed_qty"])
+
 			if not req_items:
-				frappe.msgprint(_("Did not found transfered item {0} in Work Order {1}, the item not added in Stock Entry")
+				frappe.msgprint(_("Could not find transferred item {0} in Work Order {1}, the item will not be added in Stock Entry")
 					.format(item_code, self.work_order))
 				continue
 
-			req_qty = flt(req_items[0].required_qty)
-			req_qty_each = flt(req_qty / manufacturing_qty)
+			required_qty = flt(req_items[0].required_qty)
+			required_qty_each = flt(required_qty / qty_to_manufacture)
 			consumed_qty = flt(req_items[0].consumed_qty)
 
-			if trans_qty and manufacturing_qty >= (produced_qty + flt(self.fg_completed_qty)):
-				if qty >= req_qty:
-					qty = (req_qty/trans_qty) * flt(self.fg_completed_qty)
-				else:
-					qty = qty - consumed_qty
+			if remaining_qty >= flt(self.fg_completed_qty):
+				item_qty -= consumed_qty
 
 				if self.purpose == 'Manufacture':
-					# If Material Consumption is booked, must pull only remaining components to finish product
-					if consumed_qty != 0:
-						remaining_qty = consumed_qty - (produced_qty * req_qty_each)
-						exhaust_qty = req_qty_each * produced_qty
-						if remaining_qty > exhaust_qty :
-							if (remaining_qty/(req_qty_each * flt(self.fg_completed_qty))) >= 1:
-								qty =0
-							else:
-								qty = (req_qty_each * flt(self.fg_completed_qty)) - remaining_qty
+					# If a Material Consumption is already booked, pull only the remaining
+					# transferred components to finish the product(s)
+					remaining_item_qty = required_qty_each * flt(self.fg_completed_qty)
+
+					if consumed_qty == 0:
+						item_qty = remaining_item_qty
 					else:
-						qty = req_qty_each * flt(self.fg_completed_qty)
-
-
+						actual_consumed_qty = required_qty_each * produced_qty
+						remaining_consumed_qty = consumed_qty - actual_consumed_qty
+						item_qty = max(0, remaining_item_qty - remaining_consumed_qty)
 			elif backflushed_materials.get(item.item_code):
 				for d in backflushed_materials.get(item.item_code):
 					if d.get(item.warehouse):
-						if (qty > req_qty):
-							qty = req_qty
-							qty-= d.get(item.warehouse)
+						item_qty -= d.get(item.warehouse)
 
-			if qty > 0:
+			if item_qty > 0:
 				self.add_to_stock_entry_detail({
 					item.item_code: {
 						"from_warehouse": item.warehouse,
 						"to_warehouse": "",
-						"qty": qty,
+						"qty": item_qty,
 						"item_name": item.item_name,
 						"description": item.description,
 						"stock_uom": item.stock_uom,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -961,55 +961,57 @@ class StockEntry(StockController):
 		"""
 
 		# get all items already consumed for manufacture against the work order
-		consumed_materials = frappe.db.sql(query, self.work_order, ['Manufacture', 'Material Consumption for Manufacture'], as_dict=1)
+		consumed_materials = frappe.db.sql(query, (['Manufacture', 'Material Consumption for Manufacture'], self.work_order), as_dict=1)
 		backflushed_materials = {}
 		for item in consumed_materials:
 			backflushed_materials.setdefault(item.item_code, []).append({item.warehouse: item.qty})
 
 		# loop through the transferred quantities, and add an entry for each
 		# remaining item needed for manufacture, if not already consumed
-		transferred_materials = frappe.db.sql(query, self.work_order, ['Material Transfer for Manufacture'], as_dict=1)
+		transferred_materials = frappe.db.sql(query, (['Material Transfer for Manufacture'], self.work_order), as_dict=1)
 		for item in transferred_materials:
-			item_qty = item.qty
 			item_code = item.original_item or item.item_code
-			req_items = frappe.get_all('Work Order Item',
-				filters={'parent': self.work_order, 'item_code': item_code},
-				fields=["required_qty", "consumed_qty"])
+			transferred_qty = item.qty
+			transferred_qty_each = flt(transferred_qty / qty_to_manufacture)
 
-			if not req_items:
+			required_item = frappe.get_all("Work Order Item",
+				filters={'parent': self.work_order, 'item_code': item_code},
+				fields=["consumed_qty"])
+
+			if not required_item:
 				frappe.msgprint(_("Could not find transferred item {0} in Work Order {1}, the item will not be added in Stock Entry")
 					.format(item_code, self.work_order))
 				continue
 
-			required_qty = flt(req_items[0].required_qty)
-			required_qty_each = flt(required_qty / qty_to_manufacture)
-			consumed_qty = flt(req_items[0].consumed_qty)
+			consumed_qty = flt(required_item[0].consumed_qty)
 
 			if remaining_qty >= flt(self.fg_completed_qty):
-				item_qty -= consumed_qty
-
-				if self.purpose == 'Manufacture':
+				if self.purpose == "Material Consumption for Manufacture":
+					transferred_qty -= consumed_qty
+				elif self.purpose == 'Manufacture':
 					# If a Material Consumption is already booked, pull only the remaining
 					# transferred components to finish the product(s)
-					remaining_item_qty = required_qty_each * flt(self.fg_completed_qty)
+					remaining_item_qty = transferred_qty_each * flt(self.fg_completed_qty)
 
-					if consumed_qty == 0:
-						item_qty = remaining_item_qty
+					if consumed_qty == transferred_qty:
+						transferred_qty = 0
+					elif consumed_qty == 0:
+						transferred_qty = remaining_item_qty
 					else:
-						actual_consumed_qty = required_qty_each * produced_qty
+						actual_consumed_qty = transferred_qty_each * produced_qty
 						remaining_consumed_qty = consumed_qty - actual_consumed_qty
-						item_qty = max(0, remaining_item_qty - remaining_consumed_qty)
+						transferred_qty = max(0, remaining_item_qty - remaining_consumed_qty)
 			elif backflushed_materials.get(item.item_code):
 				for d in backflushed_materials.get(item.item_code):
 					if d.get(item.warehouse):
-						item_qty -= d.get(item.warehouse)
+						transferred_qty -= d.get(item.warehouse)
 
-			if item_qty > 0:
+			if transferred_qty > 0:
 				self.add_to_stock_entry_detail({
 					item.item_code: {
 						"from_warehouse": item.warehouse,
 						"to_warehouse": "",
-						"qty": item_qty,
+						"qty": transferred_qty,
 						"item_name": item.item_name,
 						"description": item.description,
 						"stock_uom": item.stock_uom,


### PR DESCRIPTION
**Ref:** [TASK-2019-00623](https://digithinkit.global/desk#Form/Task/TASK-2019-00623)

<hr>

**Problem:**

In non-discrete (process) manufacturing, production of items may require more raw materials than defined in the item's BOM. If raw material backflush is set to be based on transferred materials, the system is not honouring the setting and is instead only picking up the required quantities for that item.

**Changes:**

- (Enhancement) If transferred raw material quantity is more than the required quantity defined in the BOM, the system now proportionally consumes them for each unit of the manufactured item.
  - For example, if 10 units of a raw material item is required for producing 10 units of the production item, but 15 units are actually transferred / consumed, then 1.5 units of the raw material will be consumed per unit of the production item.
- (Format) Made the codebase slightly easier to read.
- (Format) De-duplicated the stock queries.

<hr>

**Screenshots / GIFs:**

**Before:**

![before-stock-fix](https://user-images.githubusercontent.com/13396535/64612371-446bb800-d3f1-11e9-9034-fc7dde1e5523.gif)

**After:**

![after-stock-fix](https://user-images.githubusercontent.com/13396535/64612377-46ce1200-d3f1-11e9-9107-0c8c6a3f70fc.gif)