### PR TITLE
 fix(department): stop appending company name while renaming a department

### DIFF
--- a/erpnext/hr/doctype/department/department.py
+++ b/erpnext/hr/doctype/department/department.py
@@ -23,13 +23,6 @@ class Department(NestedSet):
 			if root:
 				self.parent_department = root
 
-	def before_rename(self, old, new, merge=False):
-		# renaming consistency with abbreviation
-		if not frappe.get_cached_value('Company',  self.company,  'abbr') in new:
-			new = get_abbreviated_name(new, self.company)
-
-		return new
-
 	def on_update(self):
 		NestedSet.on_update(self)
 


### PR DESCRIPTION
**Task:** [TASK-2019-00784](https://digithinkit.global/desk#Form/Task/TASK-2019-00784)

**Screenshots/Gifs:**

![department](https://user-images.githubusercontent.com/13060550/68589458-ec653680-04b1-11ea-9d85-435542ab769e.gif)
