### PR TITLE
fix: only HR Managers can make backdated leave applications

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -74,6 +74,10 @@ class LeaveApplication(Document):
 						frappe.throw(_("{0} applicable after {1} working days").format(self.leave_type, leave_type.applicable_after))
 
 	def validate_dates(self):
+		if self.from_date < frappe.utils.today():
+			if "HR Manager" not in frappe.get_roles(frappe.session.user):
+				frappe.throw(_("Only HR Managers can create backdated leave entries"))
+
 		if self.from_date and self.to_date and (getdate(self.to_date) < getdate(self.from_date)):
 			frappe.throw(_("To date cannot be before from date"))
 

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -74,9 +74,9 @@ class LeaveApplication(Document):
 						frappe.throw(_("{0} applicable after {1} working days").format(self.leave_type, leave_type.applicable_after))
 
 	def validate_dates(self):
-		if self.from_date < frappe.utils.today():
-			if "HR Manager" not in frappe.get_roles(frappe.session.user):
-				frappe.throw(_("Only HR Managers can create backdated leave entries"))
+		if self.from_date and self.from_date < frappe.utils.today():
+			if "HR Manager" not in frappe.get_roles():
+				frappe.throw(_("Only HR Managers can create backdated leave applications"))
 
 		if self.from_date and self.to_date and (getdate(self.to_date) < getdate(self.from_date)):
 			frappe.throw(_("To date cannot be before from date"))


### PR DESCRIPTION
[TASK-2019-00822](https://digithinkit.global/desk#Form/Task/TASK-2019-00822)

Changes made:
- Backdated leave applications cannot be made by a non-HR Manager

Steps to test backdated leave as a non-HR Manager:
1. Create a backdate leave application as a non-HR Manager
1. Error message should prevent the application from being saved

Steps to test backdated leave as an HR Manager:
1. Create a backdate leave application as an HR Manager
1. Application can be saved and submitted