### PR TITLE
feat(employee): send birthdays reminders to employees in the same com…

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -273,15 +273,20 @@ def send_birthday_reminders():
 	if int(frappe.db.get_single_value("HR Settings", "stop_birthday_reminders") or 0):
 		return
 	employees = get_employees_born_today()
-	if employees:
-		recipients_list = frappe.get_all('Employee', filters={'status': 'Active'})
-		recipients = get_employee_emails(recipients_list)
+	companies_with_employee_birthdays = set(employee.get('company') for employee in employees)
 
+	if employees:
+		fields = ['name', 'company']
+		filters = {'status': 'Active', 'company': ('in', companies_with_employee_birthdays)}
+		recipients_list = frappe.get_all('Employee', fields=fields, filters=filters)
 		birthday_email_template = frappe.db.get_single_value("HR Settings", "birthday_email_template")
 		if birthday_email_template:
 			email_template = frappe.get_doc("Email Template", birthday_email_template)
 
 		for employee in employees:
+			recipients = [recipient.get('name') for recipient in recipients_list if recipient.get('company') == employee.company]
+			recipients = get_employee_emails(recipients)
+
 			if birthday_email_template:
 				message = frappe.render_template(email_template.response, employee)
 				subject = frappe.render_template(email_template.subject, employee)


### PR DESCRIPTION
**Handle birthday reminders for multi-company setup:** - 

Send birthday reminders to employees that belong to the same company as that of the birthday guy/girl does. Handle the same for multiple birthdays.