### PR TITLE
fix: replace ERPNext Settings listing with Bloomstack Settings in Desk

### DIFF
--- a/erpnext/config/settings.py
+++ b/erpnext/config/settings.py
@@ -11,7 +11,7 @@ def get_data():
 				{
 					"type": "doctype",
 					"name": "Global Defaults",
-					"label": _("ERPNext Settings"),
+					"label": _("Bloomstack Settings"),
 					"description": _("Set Default Values like Company, Currency, Current Fiscal Year, etc."),
 					"hide_count": True,
 					"settings": 1,


### PR DESCRIPTION
Replace ERPNext Settings listing with Bloomstack Settings in Desk