### PR TITLE
fix: employee cannot set/edit time field for checkin doctype

### DIFF
--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.js
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on('Employee Checkin', {
 	setup: (frm) => {
-		if(frm.doc.time == "") {
+		if(!frm.doc.time) {
 			frm.set_value("time", frappe.datetime.now_datetime());
 		}
 	}

--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.js
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.js
@@ -2,7 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Employee Checkin', {
-	// refresh: function(frm) {
-
-	// }
+	setup: (frm) => {
+		if(frm.doc.time == "") {
+			frm.set_value("time", frappe.datetime.now_datetime());
+		}
+	}
 });

--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.json
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "EMP-CKIN-.MM.-.YYYY.-.######",
  "creation": "2019-06-10 11:56:34.536413",
@@ -23,7 +24,6 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -32,12 +32,14 @@
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Employee Name",
    "read_only": 1
   },
   {
    "fieldname": "log_type",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Log Type",
    "options": "\nIN\nOUT"
   },
@@ -58,6 +60,7 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Time",
+   "permlevel": 1,
    "reqd": 1
   },
   {
@@ -103,7 +106,8 @@
    "label": "Shift Actual End"
   }
  ],
- "modified": "2019-07-23 23:47:33.975263",
+ "links": [],
+ "modified": "2020-01-20 00:59:39.792700",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",
@@ -147,9 +151,41 @@
    "role": "HR User",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Employee",
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "title_field": "employee_name",
  "track_changes": 1
 }

--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.py
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.py
@@ -172,4 +172,3 @@ def time_diff_in_hours(start, end):
 
 def find_index_in_dict(dict_list, key, value):
 	return next((index for (index, d) in enumerate(dict_list) if d[key] == value), None)
-


### PR DESCRIPTION
Changes made:
- Time field in Employee Checkin Doctype is set to current time automatically.
- Employee cannot set/edit Time field in Employee Checkin DocType.
- Only HR Managers, HR Users and System Managers can see/edit Time field.

Steps to test:
1. Create a checkin/checkout as a User with only Employee permissions
1. Time field should not be visible or editable
1. Open the same document as an HR Manager, HR User or System Manager
1. Datetime field should be visible and editable

