### PR TITLE
fix: only fetch driver address if not set

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.json
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.json
@@ -166,6 +166,7 @@
   },
   {
    "fetch_from": "driver.address",
+   "fetch_if_empty": 1,
    "fieldname": "driver_address",
    "fieldtype": "Link",
    "label": "Driver Address",
@@ -187,7 +188,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-24 03:18:52.405757",
+ "modified": "2020-01-26 22:37:14.824021",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Trip",


### PR DESCRIPTION
**Problem:**

Manually setting a driver's address in a Delivery Trip would get overridden by any address stored in the Driver's record, causing to unexpected behaviour.