### PR TITLE
fix: delivery note creation from pick list if no sales orders found

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -3,18 +3,23 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-import frappe
+
 import json
-from six import iteritems
-from frappe.model.document import Document
-from frappe import _
 from collections import OrderedDict
-from frappe.utils import floor, flt, today, cint
-from frappe.model.mapper import get_mapped_doc, map_child_doc
+
+from six import iteritems
+
+import frappe
+from erpnext.selling.doctype.sales_order.sales_order import \
+	make_delivery_note as create_delivery_note_from_sales_order
 from erpnext.stock.get_item_details import get_conversion_factor
-from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note as create_delivery_note_from_sales_order
+from frappe import _
+from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc, map_child_doc
+from frappe.utils import cint, floor, flt, today
 
 # TODO: Prioritize SO or WO group warehouse
+
 
 class PickList(Document):
 	def before_save(self):
@@ -233,7 +238,7 @@ def create_delivery_note(source_name, target_doc=None):
 	sales_orders = [d.sales_order for d in pick_list.locations]
 	sales_orders = set(sales_orders)
 
-	delivery_note = None
+	delivery_note = frappe.new_doc("Delivery Note")
 	for sales_order in sales_orders:
 		delivery_note = create_delivery_note_from_sales_order(sales_order,
 			delivery_note, skip_item_mapping=True)


### PR DESCRIPTION
**Problem:**

If there are no sales orders against a Pick List, the system throws a validation while trying to create a new Delivery Note, which breaks the flow.

**Solution:**

If no sales orders are found, default to an empty Delivery Note.