### PR TITLE
fix: change breadcrumb of brand doctype to stock

### DIFF
--- a/erpnext/public/js/conf.js
+++ b/erpnext/public/js/conf.js
@@ -50,7 +50,7 @@ $.extend(frappe.breadcrumbs.preferred, {
 	"Territory": "Selling",
 	"Sales Person": "Selling",
 	"Sales Partner": "Selling",
-	"Brand": "Selling"
+	"Brand": "Stock"
 });
 
 $.extend(frappe.breadcrumbs.module_map, {


### PR DESCRIPTION
Changes made:
- Breadcrumb for Brand DocType changed from Selling to Stock

Steps to test:
1. Open Brand DocType
1. Breadcrumb in top left corner should be Stock as shown below

![image](https://user-images.githubusercontent.com/33743873/73424130-01848f80-4354-11ea-93d8-07f826149139.png)
