### PR TITLE
fix: full day leaves not tagged as half day in attendance

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -113,7 +113,7 @@ frappe.ui.form.on("Leave Application", {
 			}
 		}
 		else {
-			frm.doc.half_day_date = "";
+			frm.set_value("half_day_date", "");
 		}
 		frm.trigger("calculate_total_days");
 	},

--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -104,11 +104,16 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	half_day: function(frm) {
-		if (frm.doc.from_date == frm.doc.to_date) {
-			frm.set_value("half_day_date", frm.doc.from_date);
+		if (frm.doc.half_day) {
+			if (frm.doc.from_date == frm.doc.to_date) {
+				frm.set_value("half_day_date", frm.doc.from_date);
+			}
+			else {
+				frm.trigger("half_day_datepicker");
+			}
 		}
 		else {
-			frm.trigger("half_day_datepicker");
+			frm.doc.half_day_date = "";
 		}
 		frm.trigger("calculate_total_days");
 	},

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -33,6 +33,7 @@ class LeaveApplication(Document):
 		self.validate_block_days()
 		self.validate_salary_processed_days()
 		self.validate_attendance()
+
 		if frappe.db.get_value("Leave Type", self.leave_type, 'is_optional_leave'):
 			self.validate_optional_leave()
 		self.validate_applicable_after()

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -33,7 +33,6 @@ class LeaveApplication(Document):
 		self.validate_block_days()
 		self.validate_salary_processed_days()
 		self.validate_attendance()
-
 		if frappe.db.get_value("Leave Type", self.leave_type, 'is_optional_leave'):
 			self.validate_optional_leave()
 		self.validate_applicable_after()


### PR DESCRIPTION
Changes made:
- Half Day Date in Doc cleared when the Half Day checkbox is deselected

Steps to test:
- Create a leave application with half day set and save
- Deselect the half day checkbox, save and submit
- View the attendance record for that employee
- The attendance should say "On Leave"
- Repeat the same keeping the checkbox selected and submit
- The attendance should say "Half Day"