### PR TITLE
feat: column width increased for view attachments field

### DIFF
--- a/erpnext/projects/doctype/project_user/project_user.json
+++ b/erpnext/projects/doctype/project_user/project_user.json
@@ -47,6 +47,7 @@
    "fetch_from": "user.full_name",
    "fieldname": "full_name",
    "fieldtype": "Read Only",
+   "in_list_view": 1,
    "label": "Full Name"
   },
   {
@@ -76,7 +77,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-02-06 04:41:20.242607",
+ "modified": "2020-02-09 23:26:50.321417",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project User",

--- a/erpnext/projects/doctype/project_user/project_user.json
+++ b/erpnext/projects/doctype/project_user/project_user.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2016-03-25 02:52:19.283003",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -55,7 +56,7 @@
    "label": "Welcome email sent"
   },
   {
-   "columns": 1,
+   "columns": 2,
    "default": "0",
    "fieldname": "view_attachments",
    "fieldtype": "Check",
@@ -74,7 +75,8 @@
   }
  ],
  "istable": 1,
- "modified": "2019-07-15 19:37:26.942294",
+ "links": [],
+ "modified": "2020-02-06 04:41:20.242607",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project User",


### PR DESCRIPTION
**Task link**: https://corp.bloomstack.com/desk#Form/Task/TASK-2020-00036

**Description**: Width of the "View attachments" column has increased as it wasn't completely visible(readable) earlier.

**Screenshots**: 
**Before**:
![before](https://user-images.githubusercontent.com/49683121/73939380-59506700-490f-11ea-8c53-bec3695963dd.png)

**After**:
![after](https://user-images.githubusercontent.com/49683121/73939396-5f464800-490f-11ea-8f0a-515f3e930585.png)
