### PR TITLE
feat: notify credit controller role users with credit limit extension requests

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -3,16 +3,19 @@
 
 from __future__ import unicode_literals
 import frappe
+import json
 from frappe.model.naming import set_name_by_naming_series
-from frappe import _, msgprint, throw
+from frappe import _, msgprint
 import frappe.defaults
-from frappe.utils import flt, cint, cstr, today
+from frappe.utils import flt, cint, cstr, today, get_formatted_email
 from frappe.desk.reportview import build_match_conditions, get_filters_cond
 from erpnext.utilities.transaction_base import TransactionBase
 from erpnext.accounts.party import validate_party_accounts, get_dashboard_info, get_timeline_data # keep this
 from frappe.contacts.address_and_contact import load_address_and_contact, delete_contact_and_address
 from frappe.model.rename_doc import update_linked_doctypes
 from frappe.model.mapper import get_mapped_doc
+from frappe.utils.user import get_users_with_role
+
 
 class Customer(TransactionBase):
 	def get_feed(self):
@@ -333,10 +336,45 @@ def check_credit_limit(customer, company, ignore_outstanding_sales_order=False, 
 			.format(customer, customer_outstanding, credit_limit))
 
 		# If not authorized person raise exception
-		credit_controller = frappe.db.get_value('Accounts Settings', None, 'credit_controller')
-		if not credit_controller or credit_controller not in frappe.get_roles():
-			throw(_("Please contact to the user who have Sales Master Manager {0} role")
-				.format(" / " + credit_controller if credit_controller else ""))
+		credit_controller_role = frappe.db.get_single_value('Accounts Settings', 'credit_controller')
+		if not credit_controller_role or credit_controller_role not in frappe.get_roles():
+			# form a list of emails for the credit controller users
+			credit_controller_users = get_users_with_role(credit_controller_role or "Sales Master Manager")
+
+			# form a list of emails and names to show to the user
+			credit_controller_users_list = [user for user in credit_controller_users if frappe.db.exists("Employee", {"prefered_email": user})]
+			credit_controller_users = [get_formatted_email(user).replace("<", "(").replace(">", ")") for user in credit_controller_users_list]
+
+			if not credit_controller_users:
+				frappe.throw(_("Please contact your administrator to extend the credit limits for {0}.".format(customer)))
+
+			message = """Please contact any of the following users to extend the credit limits for {0}:
+				<br><br><ul><li>{1}</li></ul>""".format(customer, '<li>'.join(credit_controller_users))
+
+			# if the current user does not have permissions to override credit limit,
+			# prompt them to send out an email to the controller users
+			frappe.msgprint(message,
+				title="Notify",
+				raise_exception=1,
+				primary_action={
+					'label': 'Send Email',
+					'server_action': 'erpnext.selling.doctype.customer.customer.send_emails',
+					'args': {
+						'customer': customer,
+						'customer_outstanding': customer_outstanding,
+						'credit_limit': credit_limit,
+						'credit_controller_users_list': credit_controller_users_list
+					}
+				}
+			)
+
+@frappe.whitelist()
+def send_emails(args):
+	args = json.loads(args)
+	subject = (_("Credit limit reached for customer {0}").format(args.get('customer')))
+	message = (_("Credit limit has been crossed for customer {0} ({1}/{2})")
+			.format(args.get('customer'), args.get('customer_outstanding'), args.get('credit_limit')))
+	frappe.sendmail(recipients=[args.get('credit_controller_users_list')], subject=subject, message=message)
 
 def get_customer_outstanding(customer, company, ignore_outstanding_sales_order=False, cost_center=None):
 	# Outstanding based on GL Entries


### PR DESCRIPTION
**Ref:** [TASK-2020-00117](https://corp.bloomstack.com/desk#Form/Task/TASK-2020-00117)

<hr>

**Changes:**
- Show which users can be contacted to increase the customer's credit limits

**Todo:**
- Send a notification to the users with the set role, or default to Sales Master Managers in the system, or fallback to a default "Contact your admin" message.