### PR TITLE
fix: auto-attach consumed batches through manufacturing (#329) [TEMP]

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -439,7 +439,7 @@ class StockEntry(StockController):
 				"purpose": "Material Transfer for Manufacture"}, "name")
 
 		for d in self.get('items'):
-			transferred_serial_no, transferred_batch_no= frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
+			transferred_serial_no, transferred_batch_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
 				"item_code": d.item_code}, ["serial_no", "batch_no"])
 
 			if transferred_serial_no:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -441,10 +441,16 @@ class StockEntry(StockController):
 		for d in self.get('items'):
 			transferred_serial_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
 				"item_code": d.item_code}, "serial_no")
+			
+			transferred_batch_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
+				"item_code": d.item_code}, "batch_no")
 
 			if transferred_serial_no:
 				d.serial_no = transferred_serial_no
-
+			
+			if transferred_batch_no:
+				d.batch_no = transferred_batch_no
+			
 	def get_stock_and_rate(self):
 		self.set_work_order_details()
 		self.set_transfer_qty()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -434,16 +434,13 @@ class StockEntry(StockController):
 						frappe.bold(d.transfer_qty)),
 					NegativeStockError, title=_('Insufficient Stock'))
 
-	def set_serial_nos(self, work_order):
+	def set_serial_batch_nos(self, work_order):
 		previous_se = frappe.db.get_value("Stock Entry", {"work_order": work_order,
 				"purpose": "Material Transfer for Manufacture"}, "name")
 
 		for d in self.get('items'):
-			transferred_serial_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
-				"item_code": d.item_code}, "serial_no")
-			
-			transferred_batch_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
-				"item_code": d.item_code}, "batch_no")
+			transferred_serial_no, transferred_batch_no= frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
+				"item_code": d.item_code}, ["serial_no", "batch_no"])
 
 			if transferred_serial_no:
 				d.serial_no = transferred_serial_no
@@ -918,7 +915,7 @@ class StockEntry(StockController):
 
 			# fetch the serial_no of the first stock entry for the second stock entry
 			if self.work_order and self.purpose == "Manufacture":
-				self.set_serial_nos(self.work_order)
+				self.set_serial_batch_nos(self.work_order)
 				work_order = frappe.get_doc('Work Order', self.work_order)
 				add_additional_cost(self, work_order)
 


### PR DESCRIPTION
Fetched batch number in stock_entry.py and applied to item

Before:
![Batch_no_Task](https://user-images.githubusercontent.com/56826544/75663537-fd22fd80-5c96-11ea-94e7-e09b4048b76a.gif)


After:
![batch_number_fix](https://user-images.githubusercontent.com/56826544/75663550-044a0b80-5c97-11ea-80f4-fd96daaa4b8b.gif)
