### PR TITLE
fix: added a Reason for Return field for each items

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -147,9 +147,7 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 
 			if (doc.docstatus==1) {
 				this.frm.add_custom_button(__('Sales Return'), function() {
-					me.reason_popup(),
-					me.make_sales_return() 
-				}, __('Create'));
+					me.show_rejection_prompt()}, __('Create'));
 			}
 
 			if (doc.docstatus==1) {
@@ -220,57 +218,77 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 			frm: this.frm
 		});
 	},
-	reason_popup: function(){
-		this.data = cur_frm.doc.items||[];
-			const dialog = new frappe.ui.Dialog({
-				title: __("Select Difference Account"),
-				fields: [
-					{
-						fieldname: "items", fieldtype: "Table",cannot_add_rows: true, label: __("ITEMS"),
-						data: this.data, in_place_edit: true,
-						get_data: () => {this.data=map(
-							item=>{
-								console.log("asdcvgfdxvgfdxgfdxcvfd");
-								item_name=item.item_name;
-								reason_for_return=item.reason_for_return;
-							}
-						)
 
-							return this.data;
-						},
-						fields: [{
-							fieldtype:'Data',
-							fieldname:"docname",
-							in_list_view: 1,
+	show_rejection_prompt: function () {
+		const me = this;
+		this.data = [];
+
+		for (let row of this.frm.doc.items) {
+			this.data.push({
+				"name": row.name,
+				"item_code": row.item_code,
+				"item_name": row.item_name
+			})
+		}
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Select Reasons for Rejection"),
+			fields: [
+				{
+					label: __("Items"),
+					fieldname: "items",
+					fieldtype: "Table",
+					cannot_add_rows: true,
+					data: this.data,
+					in_place_edit: true,
+					fields: [
+						{
+							fieldtype: 'Data',
+							fieldname: "name",
 							hidden: 1
-						}, {
-							fieldtype:'Data',
-							fieldname:"item_name",
-							label: __("ITEM NAME"),
+						},
+						{
+							label: __("Item Code"),
+							fieldtype: 'Link',
+							fieldname: "item_code",
+							options: "Item",
 							in_list_view: 1,
-							read_only: 0
-						}, {
-							fieldtype:'Small Text',
+							disabled: 0
+						},
+						{
+							label: __("Item Name"),
+							fieldtype: 'Data',
+							fieldname: "item_name",
 							in_list_view: 1,
-							label: __("REASON FOR RETURN"),
+							disabled: 0
+						},
+						{
+							label: __("Reason for Return"),
+							fieldtype: 'Data',
 							fieldname: 'reason_for_return',
-						}]
-					},
-				],
-				primary_action: function() {
-					const args = dialog.get_values()["payments"];
-
-					args.forEach(d => {
-						frappe.model.set_value("Delivery Note Item", d.item_name,
-							"reason_for_return", d.reason_for_return);
-					});
-					dialog.hide();
+							in_list_view: 1
+						}
+					],
+					get_data: () => {
+						return this.data;
+					}
 				},
-				primary_action_label: __('Save')
-			});
-			dialog.show();
+			],
+			primary_action: function () {
+				const values = dialog.get_values().items;
+
+				values.forEach(d => {
+					frappe.model.set_value("Delivery Note Item", d.name, "reason_for_return", d.reason_for_return);
+				});
+
+				dialog.hide();
+				me.make_sales_return()
+			},
+			primary_action_label: __('Save')
+		});
+		dialog.show();
 	},
-	
+
 	make_sales_return: function() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.stock.doctype.delivery_note.delivery_note.make_sales_return",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -147,7 +147,7 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 
 			if (doc.docstatus==1) {
 				this.frm.add_custom_button(__('Sales Return'), function() {
-					me.show_rejection_prompt()}, __('Create'));
+					me.make_sales_return()}, __('Create'));
 			}
 
 			if (doc.docstatus==1) {
@@ -203,6 +203,12 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 				erpnext.utils.make_subscription(doc.doctype, doc.name)
 			}, __('Create'))
 		}
+
+		if (doc.docstatus == 0 && doc.is_return) {
+			cur_frm.add_custom_button(__('Reason(s) for Return'), function () {
+				me.show_return_reasons_prompt(cur_frm.doc);
+			}, __('Update'))
+		}
 	},
 
 	make_sales_invoice: function() {
@@ -219,20 +225,20 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 		});
 	},
 
-	show_rejection_prompt: function () {
-		const me = this;
+	show_return_reasons_prompt: function (doc) {
 		this.data = [];
 
-		for (let row of this.frm.doc.items) {
+		for (let row of doc.items) {
 			this.data.push({
-				"name": row.name,
+				"docname": row.name,
 				"item_code": row.item_code,
-				"item_name": row.item_name
+				"item_name": row.item_name,
+				"reason_for_return": row.reason_for_return
 			})
 		}
 
 		const dialog = new frappe.ui.Dialog({
-			title: __("Select Reasons for Rejection"),
+			title: __("Set Reason(s) for Return"),
 			fields: [
 				{
 					label: __("Items"),
@@ -241,10 +247,13 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 					cannot_add_rows: true,
 					data: this.data,
 					in_place_edit: true,
+					get_data: () => {
+						return this.data;
+					},
 					fields: [
 						{
 							fieldtype: 'Data',
-							fieldname: "name",
+							fieldname: "docname",
 							hidden: 1
 						},
 						{
@@ -252,15 +261,15 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 							fieldtype: 'Link',
 							fieldname: "item_code",
 							options: "Item",
-							in_list_view: 1,
-							disabled: 0
+							read_only: 1,
+							in_list_view: 1
 						},
 						{
 							label: __("Item Name"),
 							fieldtype: 'Data',
 							fieldname: "item_name",
-							in_list_view: 1,
-							disabled: 0
+							read_only: 1,
+							in_list_view: 1
 						},
 						{
 							label: __("Reason for Return"),
@@ -268,31 +277,33 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 							fieldname: 'reason_for_return',
 							in_list_view: 1
 						}
-					],
-					get_data: () => {
-						return this.data;
-					}
+					]
 				},
 			],
 			primary_action: function () {
 				const values = dialog.get_values().items;
-
 				values.forEach(d => {
-					frappe.model.set_value("Delivery Note Item", d.name, "reason_for_return", d.reason_for_return);
+					frappe.model.set_value("Delivery Note Item", d.docname, "reason_for_return", d.reason_for_return);
 				});
 
 				dialog.hide();
-				me.make_sales_return()
+				frappe.show_alert({
+					indicator: 'green',
+					message: __("The reason(s) for return have been successfully set")
+				});
 			},
-			primary_action_label: __('Save')
+			primary_action_label: __('Update')
 		});
 		dialog.show();
 	},
 
 	make_sales_return: function() {
+		const me = this;
 		frappe.model.open_mapped_doc({
 			method: "erpnext.stock.doctype.delivery_note.delivery_note.make_sales_return",
 			frm: this.frm
+		}).then((note) => {
+			me.show_return_reasons_prompt(note.message);
 		})
 	},
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -147,7 +147,9 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 
 			if (doc.docstatus==1) {
 				this.frm.add_custom_button(__('Sales Return'), function() {
-					me.make_sales_return() }, __('Create'));
+					me.reason_popup(),
+					me.make_sales_return() 
+				}, __('Create'));
 			}
 
 			if (doc.docstatus==1) {
@@ -218,7 +220,57 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 			frm: this.frm
 		});
 	},
+	reason_popup: function(){
+		this.data = cur_frm.doc.items||[];
+			const dialog = new frappe.ui.Dialog({
+				title: __("Select Difference Account"),
+				fields: [
+					{
+						fieldname: "items", fieldtype: "Table",cannot_add_rows: true, label: __("ITEMS"),
+						data: this.data, in_place_edit: true,
+						get_data: () => {this.data=map(
+							item=>{
+								console.log("asdcvgfdxvgfdxgfdxcvfd");
+								item_name=item.item_name;
+								reason_for_return=item.reason_for_return;
+							}
+						)
 
+							return this.data;
+						},
+						fields: [{
+							fieldtype:'Data',
+							fieldname:"docname",
+							in_list_view: 1,
+							hidden: 1
+						}, {
+							fieldtype:'Data',
+							fieldname:"item_name",
+							label: __("ITEM NAME"),
+							in_list_view: 1,
+							read_only: 0
+						}, {
+							fieldtype:'Small Text',
+							in_list_view: 1,
+							label: __("REASON FOR RETURN"),
+							fieldname: 'reason_for_return',
+						}]
+					},
+				],
+				primary_action: function() {
+					const args = dialog.get_values()["payments"];
+
+					args.forEach(d => {
+						frappe.model.set_value("Delivery Note Item", d.item_name,
+							"reason_for_return", d.reason_for_return);
+					});
+					dialog.hide();
+				},
+				primary_action_label: __('Save')
+			});
+			dialog.show();
+	},
+	
 	make_sales_return: function() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.stock.doctype.delivery_note.delivery_note.make_sales_return",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -81,9 +81,9 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
-  "reason_for_return_section_break",
+  "sb_return",
   "reason_for_return",
-  "reason_for_reaturn_column_break",
+  "cb_return",
   "section_break_72",
   "page_break"
  ],
@@ -704,30 +704,30 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "0",
+   "depends_on": "eval:parent.is_return==1;",
+   "fieldname": "sb_return",
+   "fieldtype": "Section Break",
+   "label": "Reason for Return"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:parent.is_return==1;",
+   "fieldname": "cb_return",
+   "fieldtype": "Column Break",
+   "in_standard_filter": 1
+  },
+  {
    "depends_on": "eval:parent.is_return==1;",
    "fieldname": "reason_for_return",
    "fieldtype": "Small Text",
-   "label": "Reason for Return",
-   "no_copy": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:parent.is_return==1;",
-   "fieldname": "reason_for_return_section_break",
-   "fieldtype": "Section Break",
    "label": "Reason For Return"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:parent.is_return==1;",
-   "fieldname": "reason_for_reaturn_column_break",
-   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-03 23:37:32.080835",
+ "modified": "2020-03-17 22:50:59.687494",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -704,11 +704,13 @@
    "fieldtype": "Column Break"
   },
   {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:parent.is_return==1",
    "default": "0",
-   "depends_on": "eval:parent.is_return==1;",
+   "depends_on": "eval:parent.is_return==1",
    "fieldname": "sb_return",
    "fieldtype": "Section Break",
-   "label": "Reason for Return"
+   "label": "Returns"
   },
   {
    "default": "0",
@@ -727,7 +729,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-17 22:50:59.687494",
+ "modified": "2020-03-22 22:21:21.117822",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-04-22 13:15:44",
  "doctype": "DocType",
@@ -80,6 +81,9 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "reason_for_return_section_break",
+  "reason_for_return",
+  "reason_for_reaturn_column_break",
   "section_break_72",
   "page_break"
  ],
@@ -698,11 +702,32 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:parent.is_return==1;",
+   "fieldname": "reason_for_return",
+   "fieldtype": "Small Text",
+   "label": "Reason for Return",
+   "no_copy": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:parent.is_return==1;",
+   "fieldname": "reason_for_return_section_break",
+   "fieldtype": "Section Break",
+   "label": "Reason For Return"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:parent.is_return==1;",
+   "fieldname": "reason_for_reaturn_column_break",
+   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-25 22:08:27.452734",
+ "links": [],
+ "modified": "2020-03-03 23:37:32.080835",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",


### PR DESCRIPTION
Added a field "Reason for Return" when creating Sales Return of Delivery Note for each items.

Before:
![delivery_note_task](https://user-images.githubusercontent.com/56826544/75861547-9252fd00-5e23-11ea-9448-83f2a888a570.gif)

After
![reason_for_return](https://user-images.githubusercontent.com/56826544/77291978-5b2a8a00-6d05-11ea-9d7a-2e54714726a4.gif)

