### PR TITLE
feat(selling): added delivery window in sales order

### DIFF
--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -30,10 +30,6 @@
   "represents_company",
   "allowed_to_transact_section",
   "companies",
-  "delivery_window",
-  "delivery_start_time",
-  "column_break_22",
-  "delivery_end_time",
   "currency_and_price_list",
   "default_currency",
   "default_price_list",
@@ -53,6 +49,10 @@
   "primary_address",
   "default_receivable_accounts",
   "accounts",
+  "delivery_window",
+  "delivery_start_time",
+  "column_break_42",
+  "delivery_end_time",
   "credit_limit_section",
   "payment_terms",
   "credit_limits",
@@ -472,10 +472,6 @@
    "options": "Customer Credit Limit"
   },
   {
-   "fieldname": "column_break_22",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "delivery_end_time",
    "fieldtype": "Time",
    "label": "Delivery End Time"
@@ -490,13 +486,17 @@
    "fieldname": "delivery_start_time",
    "fieldtype": "Time",
    "label": "Delivery Start Time"
+  },
+  {
+   "fieldname": "column_break_42",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-user",
  "idx": 363,
  "image_field": "image",
  "links": [],
- "modified": "2020-01-29 20:36:37.879581",
+ "modified": "2020-03-26 03:04:46.953704",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -35,6 +35,25 @@ frappe.ui.form.on("Sales Order", {
 			};
 		})
 	},
+	customer: function (frm) {
+		frappe.call({
+			method: "erpnext.stock.doctype.delivery_trip.delivery_trip.get_delivery_window",
+			args: { customer: frm.doc.customer },
+			callback: function (r) {
+				if (r.message && (r.message.delivery_start_time || r.message.delivery_end_time)) {
+					frm.set_value("delivery_start_time", r.message.delivery_start_time);
+					frm.set_value("delivery_end_time", r.message.delivery_end_time);
+					frappe.show_alert({
+						indicator: 'blue',
+						message: __(r.message.default_window
+							? "Delivery window set to global default"
+							: "Delivery window set to customer default"
+						)
+					});
+				}
+			}
+		});
+	},
 	refresh: function(frm) {
 		if(frm.doc.docstatus === 1 && frm.doc.status !== 'Closed'
 			&& flt(frm.doc.per_delivered, 6) < 100 && flt(frm.doc.per_billed, 6) < 100) {

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -99,6 +99,10 @@
   "advance_paid",
   "packing_list",
   "packed_items",
+  "delivery_window",
+  "delivery_start_time",
+  "column_break_19",
+  "delivery_end_time",
   "payment_schedule_section",
   "payment_terms_template",
   "payment_schedule",
@@ -1201,13 +1205,34 @@
    "hidden": 1,
    "label": "Is Completed",
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "customer",
+   "fieldname": "delivery_window",
+   "fieldtype": "Section Break",
+   "label": "Delivery Window"
+  },
+  {
+   "fieldname": "delivery_start_time",
+   "fieldtype": "Time",
+   "label": "Delivery Start Time"
+  },
+  {
+   "fieldname": "column_break_19",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "delivery_end_time",
+   "fieldtype": "Time",
+   "label": "Delivery End time"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-30 19:15:28.605085",
+ "modified": "2020-04-02 23:12:33.920545",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -102,11 +102,13 @@
   "tc_name",
   "terms",
   "transporter_info",
+  "delivery_start_time",
   "transporter",
   "driver",
   "lr_no",
   "vehicle_no",
   "col_break34",
+  "delivery_end_time",
   "transporter_name",
   "driver_name",
   "lr_date",
@@ -1235,13 +1237,25 @@
   {
    "fieldname": "section_break_18",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "delivery_start_time",
+   "fieldtype": "Time",
+   "label": "Deliver After",
+   "read_only": 1
+  },
+  {
+   "fieldname": "delivery_end_time",
+   "fieldtype": "Time",
+   "label": "Deliver Before",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-30 19:17:13.122644",
+ "modified": "2020-04-02 23:15:08.846208",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -12,6 +12,7 @@ import frappe.defaults
 from erpnext.controllers.selling_controller import SellingController
 from erpnext.stock.doctype.batch.batch import set_batch_nos
 from erpnext.stock.doctype.serial_no.serial_no import get_delivery_note_serial_no
+from erpnext.stock.doctype.delivery_trip.delivery_trip import get_delivery_window
 from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
 from frappe.desk.notifications import clear_doctype_notifications
@@ -552,6 +553,9 @@ def make_delivery_trip(source_name, target_doc=None):
 		target.package_total = sum([stop.grand_total for stop in target.delivery_stops if stop.grand_total])
 
 	def update_stop_details(source_doc, target_doc, source_parent):
+		delivery_window = get_delivery_window(source_parent.doctype, source_parent.name)
+		target_doc.delivery_start_time = delivery_window.delivery_start_time
+		target_doc.delivery_end_time = delivery_window.delivery_end_time
 		target_doc.customer = source_parent.customer
 		target_doc.address = source_parent.shipping_address_name
 		target_doc.customer_address = source_parent.shipping_address

--- a/erpnext/stock/doctype/delivery_stop/delivery_stop.json
+++ b/erpnext/stock/doctype/delivery_stop/delivery_stop.json
@@ -190,25 +190,27 @@
    "label": "Delivery Window"
   },
   {
-   "fetch_from": "customer.delivery_start_time",
+   "fetch_from": "delivery_note.delivery_start_time",
    "fieldname": "delivery_start_time",
    "fieldtype": "Time",
-   "label": "Delivery Start Time"
+   "label": "Delivery Start Time",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_18",
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "customer.delivery_end_time",
+   "fetch_from": "delivery_note.delivery_end_time",
    "fieldname": "delivery_end_time",
    "fieldtype": "Time",
-   "label": "Delivery End Time"
+   "label": "Delivery End Time",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-03-02 19:43:49.243259",
+ "modified": "2020-03-24 01:27:18.124556",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Stop",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -228,18 +228,11 @@ frappe.ui.form.on('Delivery Stop', {
 
 			frappe.call({
 				method: "erpnext.stock.doctype.delivery_trip.delivery_trip.get_delivery_window",
-				args: { customer : row.customer },
+				args: { doctype : "Delivery Note" , docname : row.delivery_note, customer : row.customer },
 				callback: function (r) {
 					if(r.message && (r.message.delivery_start_time || r.message.delivery_end_time) ){
 						frappe.model.set_value(cdt, cdn, "delivery_start_time", r.message.delivery_start_time);
 						frappe.model.set_value(cdt, cdn, "delivery_end_time", r.message.delivery_end_time);
-						frappe.show_alert({
-							indicator: 'blue',
-							message: __(r.message.default_window
-								? "Delivery window set to global default"
-								: "Delivery window set to customer default"
-							)
-						});
 					}
 				}
 			});


### PR DESCRIPTION
**Ref:** [TASK-2020-00247](https://bloomstack.com/desk#Form/Task/TASK-2020-00247)

<hr>

added delivery window in sales order where default delivery window time is fetched from customer if not set by customer then fetched from delivery settings and can be changed for particular delivery
tip in sales-order