### PR TITLE
fix(crm): fix lead while updating contact details

### DIFF
--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -19,6 +19,5 @@ def update_lead_phone_numbers(contact, method):
 					mobile_no = primary_mobile_nos[0]
 
 			lead = frappe.get_doc("Lead", contact_lead)
-			lead.phone = phone
-			lead.mobile_no = mobile_no
-			lead.save(ignore_permissions=True)
+			lead.db_set("phone", phone)
+			lead.db_set("mobile_no", mobile_no)


### PR DESCRIPTION
it use to throw error while updating contact details for lead "Next Contact Date cannot be in the past" is being solved

