### PR TITLE
feat: apply item-wise pricing rules

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -210,7 +210,7 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None, for_validate=Fa
 		"discount_amount_on_rate": []
 	})
 
-	if args.ignore_pricing_rule or not args.item_code:
+	if args.ignore_pricing_rule or args.item_ignore_pricing_rule or not args.item_code:
 		if frappe.db.exists(args.doctype, args.name) and args.get("pricing_rules"):
 			item_details = remove_pricing_rule_for_item(args.get("pricing_rules"),
 				item_details, args.get('item_code'))
@@ -247,7 +247,7 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None, for_validate=Fa
 
 			if pricing_rule.coupon_code_based==1 and args.coupon_code==None:
 				return item_details
-				
+
 			if not pricing_rule.validate_applied_rule:
 				if pricing_rule.price_or_product_discount == "Price":
 					apply_price_discount_rule(pricing_rule, item_details, args)

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -44,6 +44,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_22",
   "net_rate",
@@ -762,16 +763,21 @@
    "fetch_from": "item_code.asset_category",
    "fieldname": "asset_category",
    "fieldtype": "Data",
-   "in_preview": 1,
    "label": "Asset Category",
    "options": "Asset Category",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2019-12-04 12:23:17.046413",
+ "modified": "2020-05-08 06:11:08.386919",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -45,6 +45,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_21",
   "net_rate",
@@ -783,12 +784,18 @@
    "fieldtype": "Link",
    "label": "Finance Book",
    "options": "Finance Book"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2019-12-04 12:22:38.517710",
+ "modified": "2020-05-08 06:11:38.569638",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-05-24 19:29:06",
  "doctype": "DocType",
@@ -42,6 +43,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "is_fixed_asset",
   "section_break_29",
@@ -708,17 +710,23 @@
    "fieldtype": "Check",
    "label": "Is Fixed Asset",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-07 17:19:12.090355",
+ "links": [],
+ "modified": "2020-05-08 06:12:04.769939",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",
  "owner": "Administrator",
  "permissions": [],
- "quick_entry": 1,
  "search_fields": "item_name",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-05-22 12:43:10",
  "doctype": "DocType",
@@ -41,6 +42,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_24",
   "net_rate",
@@ -528,11 +530,18 @@
   {
    "fieldname": "column_break_15",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-02 05:32:46.019237",
+ "links": [],
+ "modified": "2020-05-08 06:12:32.611668",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -488,7 +488,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 							is_pos: cint(me.frm.doc.is_pos),
 							is_subcontracted: me.frm.doc.is_subcontracted,
 							transaction_date: me.frm.doc.transaction_date || me.frm.doc.posting_date,
-							ignore_pricing_rule: me.frm.doc.ignore_pricing_rule,
+							ignore_pricing_rule: item.item_ignore_pricing_rule,
 							doctype: me.frm.doc.doctype,
 							name: me.frm.doc.name,
 							project: item.project || me.frm.doc.project,
@@ -1173,6 +1173,10 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 
 	ignore_pricing_rule: function() {
+		for (let item of this.frm.doc["items"]) {
+			frappe.model.set_value(item.doctype, item.name, "item_ignore_pricing_rule", this.frm.doc.ignore_pricing_rule);
+		}
+
 		if(this.frm.doc.ignore_pricing_rule) {
 			var me = this;
 			var item_list = [];
@@ -1184,6 +1188,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						"name": d.name,
 						"item_code": d.item_code,
 						"pricing_rules": d.pricing_rules,
+						"ignore_pricing_rule": d.item_ignore_pricing_rule,
 						"parenttype": d.parenttype,
 						"parent": d.parent
 					})
@@ -1203,6 +1208,31 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					}
 				}
 			});
+		} else {
+			this.apply_pricing_rule();
+		}
+	},
+
+	item_ignore_pricing_rule: function() {
+		const me = this;
+		const row = this.frm.selected_doc;
+		if (row.item_ignore_pricing_rule) {
+			if (row.item_code && !row.is_free_item) {
+				return this.frm.call({
+					method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.remove_pricing_rules",
+					args: { item_list: [row] },
+					callback: function (r) {
+						if (!r.exc && r.message) {
+							r.message.forEach(row_item => {
+								me.remove_pricing_rule(row_item);
+							});
+							me._set_values_for_item_list(r.message);
+							me.calculate_taxes_and_totals();
+							if (me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
+						}
+					}
+				});
+			}
 		} else {
 			this.apply_pricing_rule();
 		}
@@ -1277,6 +1307,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					"parenttype": d.parenttype,
 					"parent": d.parent,
 					"pricing_rules": d.pricing_rules,
+					"item_ignore_pricing_rule": d.item_ignore_pricing_rule,
 					"warehouse": d.warehouse,
 					"serial_no": d.serial_no,
 					"price_list_rate": d.price_list_rate,
@@ -1320,10 +1351,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			}
 
 			// if pricing rule set as blank from an existing value, apply price_list
-			if(!me.frm.doc.ignore_pricing_rule && existing_pricing_rule && !d.pricing_rules) {
-				me.apply_price_list(frappe.get_doc(d.doctype, d.name));
-			} else if(!d.pricing_rules) {
-				me.remove_pricing_rule(frappe.get_doc(d.doctype, d.name));
+			if (!d.pricing_rules) {
+				if (!d.item_ignore_pricing_rule && existing_pricing_rule) {
+					me.apply_price_list(frappe.get_doc(d.doctype, d.name));
+				} else {
+					me.remove_pricing_rule(frappe.get_doc(d.doctype, d.name));
+				}
 			}
 
 			if (d.free_item_data) {
@@ -1835,11 +1868,11 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 
 	coupon_code: function() {
-		var me = this;
+		const me = this;
 		frappe.run_serially([
-			() => this.frm.doc.ignore_pricing_rule=1,
+			() => this.frm.doc.ignore_pricing_rule = 1,
 			() => me.ignore_pricing_rule(),
-			() => this.frm.doc.ignore_pricing_rule=0,
+			() => this.frm.doc.ignore_pricing_rule = 0,
 			() => me.apply_pricing_rule()
 		]);
 	}

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2013-03-07 11:42:57",
  "doctype": "DocType",
  "document_type": "Document",
@@ -46,6 +47,7 @@
   "base_amount",
   "base_net_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "item_weight_details",
   "weight_per_unit",
@@ -382,6 +384,7 @@
    "read_only": 1
   },
   {
+   "default": "0",
    "fieldname": "is_free_item",
    "fieldtype": "Check",
    "label": "Is Free Item",
@@ -517,6 +520,7 @@
   },
   {
    "allow_on_submit": 1,
+   "default": "0",
    "fieldname": "page_break",
    "fieldtype": "Check",
    "label": "Page Break",
@@ -570,11 +574,18 @@
    "fieldname": "image_section",
    "fieldtype": "Section Break",
    "label": "Image"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-01 17:39:14.228141",
+ "links": [],
+ "modified": "2020-05-08 05:10:57.215538",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-03-07 11:42:58",
  "doctype": "DocType",
@@ -45,6 +46,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_24",
   "net_rate",
@@ -754,11 +756,18 @@
    "fieldname": "additional_notes",
    "fieldtype": "Text",
    "label": "Additional Notes"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-12-11 18:06:26.238169",
+ "links": [],
+ "modified": "2020-05-08 06:08:58.616432",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -44,6 +44,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_25",
   "net_rate",
@@ -724,12 +725,18 @@
    "fieldname": "reason_for_return",
    "fieldtype": "Small Text",
    "label": "Reason For Return"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-22 22:21:21.117822",
+ "modified": "2020-05-08 06:09:38.276790",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-05-24 19:29:10",
  "doctype": "DocType",
@@ -46,6 +47,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_29",
   "net_rate",
@@ -815,21 +817,26 @@
    "fetch_from": "item_code.asset_category",
    "fieldname": "asset_category",
    "fieldtype": "Link",
-   "in_preview": 1,
    "label": "Asset Category",
    "options": "Asset Category",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-10-14 16:03:25.499557",
+ "links": [],
+ "modified": "2020-05-08 06:10:10.448848",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",
  "owner": "Administrator",
  "permissions": [],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC"
 }


### PR DESCRIPTION
**Changes:**

- Add "Ignore Pricing Rule" checkbox in all Buying and Selling transactions that apply pricing rules.
- Re-map pricing rule triggers to pick up item toggles instead of the parent toggle.

**ToDo:**

- Discuss case where coupon code is applied on transactions with pre-applied item-level pricing rules

<hr>

**Screenshots / GIFs:**

![item-pricing-rule](https://user-images.githubusercontent.com/13396535/81396521-2d799300-9143-11ea-9b64-9085cba946d5.gif)