### PR TITLE
feat: products page is now 2 column layout

### DIFF
--- a/erpnext/public/css/products.css
+++ b/erpnext/public/css/products.css
@@ -1,0 +1,14 @@
+.products-list .card:nth-child(2n+1) {
+  margin-right: 10px;
+}
+
+.products-list .card {
+  max-width: 48%;
+}
+
+@media screen and (max-width:767px) {
+  .products-list.row.no-gutters .card { 
+    max-width: 100%;
+    margin: 0;
+  }
+}

--- a/erpnext/public/css/products.css
+++ b/erpnext/public/css/products.css
@@ -3,7 +3,7 @@
 }
 
 .products-list .card {
-  max-width: 48%;
+  max-width: 49%;
 }
 
 @media screen and (max-width:767px) {

--- a/erpnext/www/all-products/index.html
+++ b/erpnext/www/all-products/index.html
@@ -5,6 +5,10 @@
 <h1>{{ _('Products') }}</h1>
 {% endblock header %}
 
+{% block style %}
+<link rel="stylesheet" href="/assets/erpnext/css/products.css">
+{% endblock %}
+
 {% block page_content %}
 <div class="row">
 	<div class="col-8">
@@ -31,7 +35,7 @@
 </div>
 
 <div class="row">
-	<div class="col-12 order-2 col-md-8 order-md-1 products-list">
+	<div class="col-12 order-2 col-md-8 order-md-1 products-list row no-gutters">
 		{% if items %}
 			{% for item in items %}
 				{% include "erpnext/www/all-products/item_row.html" %}

--- a/erpnext/www/all-products/item_row.html
+++ b/erpnext/www/all-products/item_row.html
@@ -1,4 +1,4 @@
-<div class="card mb-3">
+<div class="card mb-3 col-md-6">
 	<div class="row no-gutters">
 		<div class="col-md-3">
 			<div class="card-body">


### PR DESCRIPTION
**Task**: The Product page should be a 2 column layout

**Screenshots:
Before:**
![productsbefore](https://user-images.githubusercontent.com/45919049/81928720-5a2a2080-9603-11ea-8013-6955e4d35b89.png)

**After:**
![productsafter](https://user-images.githubusercontent.com/45919049/81928664-41216f80-9603-11ea-80b8-27af717e3cf9.png)
