### PR TITLE
fix: only auto-set serial nos and batches if allowed in Stock Settings

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -112,12 +112,15 @@ def get_items_with_location_and_quantity(item_doc, item_location_map):
 		if item_location.serial_no:
 			serial_nos = '\n'.join(item_location.serial_no[0: cint(stock_qty)])
 
+		auto_set_serial_no = frappe.db.get_single_value("Stock Settings", "automatically_set_serial_nos_based_on_fifo")
+		auto_set_batch_no = frappe.db.get_single_value("Stock Settings", "automatically_set_batch_nos_based_on_fifo")
+
 		locations.append(frappe._dict({
 			'qty': qty,
 			'stock_qty': stock_qty,
 			'warehouse': item_location.warehouse,
-			'serial_no': serial_nos,
-			'batch_no': item_location.batch_no
+			'serial_no': serial_nos if auto_set_serial_no else None,
+			'batch_no': item_location.batch_no if auto_set_batch_no else None
 		}))
 
 		remaining_stock_qty -= stock_qty


### PR DESCRIPTION
**Ref:** [TASK-2020-00729](https://bloomstack.com/desk#Form/Task/TASK-2020-00729)

<hr>

**Before:**

![pick-list-auto-set-serial-batch-before](https://user-images.githubusercontent.com/13396535/82319130-abb12180-99ee-11ea-9a7a-ab40d585f7a2.gif)

**After:**

![pick-list-auto-set-serial-batch-after](https://user-images.githubusercontent.com/13396535/82319124-a9e75e00-99ee-11ea-88aa-025b1908b2dd.gif)
