### PR TITLE
fix: throw error if no serial numbers are found in Pick List

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -29,6 +29,9 @@ class PickList(Document):
 		for item in self.locations:
 			if not frappe.get_cached_value('Item', item.item_code, 'has_serial_no'):
 				continue
+			if not item.serial_no:
+				frappe.throw(_("Row #{0}: {1} does not have any available serial numbers in {2}".format(
+					frappe.bold(item.idx), frappe.bold(item.item_code), frappe.bold(item.warehouse))))
 			if len(item.serial_no.split('\n')) == item.picked_qty:
 				continue
 			frappe.throw(_('For item {0} at row {1}, count of serial numbers does not match with the picked quantity')


### PR DESCRIPTION
**Problem:**

If a serialized item is added to the Pick List, but no serial numbers are found, the system throws a programming error, instead of a proper error

**Screenshots / GIFs:**

![image](https://user-images.githubusercontent.com/13396535/82814322-8c196d80-9eb4-11ea-911b-a4ff946554ed.png)
