### PR TITLE
fix: fetch project-related info in Timesheet

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -3,55 +3,36 @@
 
 frappe.provide("erpnext.projects");
 
-cur_frm.add_fetch("project", "company", "company");
-
 frappe.ui.form.on("Task", {
-	onload: function(frm) {
-		frm.set_query("task", "depends_on", function() {
-			var filters = {
+	setup: function (frm) {
+		frm.set_query("project", function () {
+			return {
+				query: "erpnext.projects.doctype.task.task.get_project"
+			}
+		});
+
+		frm.make_methods = {
+			'Timesheet': () => frappe.model.open_mapped_doc({
+				method: 'erpnext.projects.doctype.task.task.make_timesheet',
+				frm: frm
+			})
+		}
+	},
+
+	onload: function (frm) {
+		frm.set_query("task", "depends_on", function () {
+			let filters = {
 				name: ["!=", frm.doc.name]
 			};
-			if(frm.doc.project) filters["project"] = frm.doc.project;
+			if (frm.doc.project) filters["project"] = frm.doc.project;
 			return {
 				filters: filters
 			};
 		})
 	},
 
-	refresh: function(frm) {
-		frm.fields_dict['parent_task'].get_query = function () {
-			return {
-				filters: {
-					"is_group": 1,
-				}
-			}
-		}
-
-		if (!frm.doc.is_group) {
-			if (!frm.is_new()) {
-				if (frappe.model.can_read("Timesheet")) {
-					frm.add_custom_button(__("Timesheet"), () => {
-						frappe.route_options = { "project": frm.doc.project, "task": frm.doc.name }
-						frappe.set_route("List", "Timesheet");
-					}, __("View"), true);
-				}
-
-				if (frappe.model.can_read("Expense Claim")) {
-					frm.add_custom_button(__("Expense Claims"), () => {
-						frappe.route_options = { "project": frm.doc.project, "task": frm.doc.name };
-						frappe.set_route("List", "Expense Claim");
-					}, __("View"), true);
-				}
-			}
-		}
-	},
-
-	setup: function(frm) {
-		frm.fields_dict.project.get_query = function() {
-			return {
-				query: "erpnext.projects.doctype.task.task.get_project"
-			}
-		};
+	refresh: function (frm) {
+		frm.set_query("parent_task", { "is_group": 1 });
 	},
 
 	is_group: function (frm) {
@@ -69,12 +50,8 @@ frappe.ui.form.on("Task", {
 		})
 	},
 
-	validate: function(frm) {
+	validate: function (frm) {
 		frm.doc.project && frappe.model.remove_from_locals("Project",
 			frm.doc.project);
-	},
-
+	}
 });
-
-cur_frm.add_fetch('task', 'subject', 'subject');
-cur_frm.add_fetch('task', 'project', 'project');

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "TASK-.YYYY.-.#####",
  "creation": "2013-01-29 19:25:50",
@@ -324,6 +325,7 @@
    "options": "Department"
   },
   {
+   "fetch_from": "project.company",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
@@ -361,8 +363,9 @@
  ],
  "icon": "fa fa-check",
  "idx": 1,
+ "links": [],
  "max_attachments": 5,
- "modified": "2019-09-10 13:46:24.631754",
+ "modified": "2020-06-24 04:30:53.712091",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -7,10 +7,11 @@ import json
 
 import frappe
 from frappe import _, throw
+from frappe.desk.form.assign_to import clear, close_all_assignments
+from frappe.model.mapper import get_mapped_doc
 from frappe.utils import add_days, cstr, date_diff, get_link_to_form, getdate, today
 from frappe.utils.nestedset import NestedSet
-from frappe.desk.form.assign_to import close_all_assignments, clear
-from frappe.utils import date_diff
+
 
 class CircularReferenceError(frappe.ValidationError): pass
 class EndDateCannotBeGreaterThanProjectEndDateError(frappe.ValidationError): pass
@@ -216,6 +217,26 @@ def set_tasks_as_overdue():
 			if getdate(frappe.db.get_value("Task", task.name, "review_date")) < getdate(today()):
 				continue
 		frappe.get_doc("Task", task.name).update_status()
+
+
+@frappe.whitelist()
+def make_timesheet(source_name, target_doc=None, ignore_permissions=False):
+	def set_missing_values(source, target):
+		target.append("time_logs", {
+			"hours": source.actual_time,
+			"completed": source.status == "Completed",
+			"project": source.project,
+			"task": source.name
+		})
+
+	doclist = get_mapped_doc("Task", source_name, {
+			"Task": {
+				"doctype": "Timesheet"
+			}
+		}, target_doc, postprocess=set_missing_values, ignore_permissions=ignore_permissions)
+
+	return doclist
+
 
 @frappe.whitelist()
 def get_children(doctype, parent, task=None, project=None, is_root=False):


### PR DESCRIPTION
**Ref:** [TASK-2020-00723](https://bloomstack.com/desk#Form/Task/TASK-2020-00723)

<hr>

**Changes:**

- On creating a new Timesheet from Task, the project and worked hours are pulled in the document as well
- Remove redundant "View" buttons for Timesheet and Expense Claim since the dashboard is already available
- Move `add_fetch` behaviour into JSON schema