### PR TITLE
feat: set default project and customer if only one found in Timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -101,12 +101,60 @@ frappe.ui.form.on("Timesheet", {
 			});
 	},
 
-	make_invoice: function(frm) {
+	make_invoice: async function(frm) {
+		let customers = [];
+		const billable_projects = frm.doc.time_logs
+			.filter(log => log.billable)
+			.map(log => log.project)
+			.filter(Boolean);
+
+		// find unique customers to bill from linked projects
+		if (billable_projects.length > 0) {
+			for (let project of billable_projects) {
+				await frappe.db.get_value("Project", { "name": project }, "customer")
+					.then((r) => {
+						customers.push(r.message.customer);
+					})
+			}
+		}
+
+		// set default customer and project if single value found
+		let project;
+		let customer;
+
+		if (customers.length == 1) {
+			customer = customers[0];
+		}
+
+		if (billable_projects.length == 1) {
+			project = billable_projects[0];
+		}
+
 		let dialog = new frappe.ui.Dialog({
 			title: __("Select Item and Customer"),
 			fields: [
-				{"fieldtype": "Link", "label": __("Item Code"), "fieldname": "item_code", "options":"Item", "reqd": 1},
-				{"fieldtype": "Link", "label": __("Customer"), "fieldname": "customer", "options":"Customer", "reqd": 1}
+				{
+					"fieldtype": "Link",
+					"label": __("Item Code"),
+					"fieldname": "item_code",
+					"options": "Item",
+					"reqd": 1
+				},
+				{
+					"fieldtype": "Link",
+					"label": __("Customer"),
+					"fieldname": "customer",
+					"options": "Customer",
+					"default": customer,
+					"reqd": 1
+				},
+				{
+					"fieldtype": "Link",
+					"label": __("Project"),
+					"fieldname": "project",
+					"options": "Project",
+					"default": project
+				},
 			]
 		});
 
@@ -120,7 +168,8 @@ frappe.ui.form.on("Timesheet", {
 				args: {
 					"source_name": frm.doc.name,
 					"item_code": args.item_code,
-					"customer": args.customer
+					"customer": args.customer,
+					"project": args.project
 				},
 				freeze: true,
 				callback: function(r) {

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -259,7 +259,7 @@ def get_timesheet_data(name, project):
 	}
 
 @frappe.whitelist()
-def make_sales_invoice(source_name, item_code=None, customer=None):
+def make_sales_invoice(source_name, item_code=None, customer=None, project=None):
 	target = frappe.new_doc("Sales Invoice")
 	timesheet = frappe.get_doc('Timesheet', source_name)
 
@@ -276,6 +276,9 @@ def make_sales_invoice(source_name, item_code=None, customer=None):
 	target.company = timesheet.company
 	if customer:
 		target.customer = customer
+
+	if project:
+		target.project = project
 
 	if item_code:
 		target.append('items', {


### PR DESCRIPTION
**Ref:** [TASK-2020-00723](https://bloomstack.com/desk#Form/Task/TASK-2020-00723)

<hr>

**Changes:**

- Add a new "Project" option in the "Create Sales Invoice" dialog box in Timesheet
- If only one customer or project needs to be billed, they're automatically fetched into the dialog box, otherwise none are selected

<hr>

**Screenshots / GIFs:**

![timesheet-customer-project](https://user-images.githubusercontent.com/13396535/86244540-bf42d100-bbc5-11ea-8ddb-0a6b48299ee8.gif)