### PR TITLE
fix: Marketing expense added to customer dashboard

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1571,14 +1571,14 @@
    "fieldname": "order_type",
    "fieldtype": "Select",
    "label": "Order Type",
-   "options": "Sales\nMarketing"
+   "options": "\nSales\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-15 03:32:21.258743",
+ "modified": "2020-07-16 01:49:06.266368",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1571,14 +1571,14 @@
    "fieldname": "order_type",
    "fieldtype": "Select",
    "label": "Order Type",
-   "options": "\nSales\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
+   "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-16 01:49:06.266368",
+ "modified": "2020-07-16 06:13:14.139976",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-24 19:29:05",
@@ -12,6 +13,7 @@
   "customer_name",
   "tax_id",
   "is_pos",
+  "order_type",
   "pos_profile",
   "offline_pos_name",
   "is_return",
@@ -1564,12 +1566,19 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "order_type",
+   "fieldtype": "Select",
+   "label": "Order Type",
+   "options": "Sales\nMarketing"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2020-02-10 04:57:11.221180",
+ "links": [],
+ "modified": "2020-07-15 03:32:21.258743",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -107,8 +107,11 @@ $.extend(erpnext.utils, {
 				frm.dashboard.add_indicator(__('Total Unpaid: {0}',
 					[format_currency(company_wise_info[0].total_unpaid, company_wise_info[0].currency)]),
 				company_wise_info[0].total_unpaid ? 'orange' : 'green');
-				frm.dashboard.add_indicator(__('Marketing Expense: {0}',
-					[format_currency(company_wise_info[0].marketing_expense, company_wise_info[0].currency)]), 'blue');
+
+				if (frm.doc.doctype === 'Customer') {
+					frm.dashboard.add_indicator(__('Marketing Expense: {0}',
+						[format_currency(company_wise_info[0].marketing_expense, company_wise_info[0].currency)]), 'blue');
+				}
 
 				if(company_wise_info[0].loyalty_points) {
 					frm.dashboard.add_indicator(__('Loyalty Points: {0}',
@@ -135,11 +138,11 @@ $.extend(erpnext.utils, {
 			'<span class="indicator '+color+'">Total Unpaid: '
 			+format_currency(info.total_unpaid, info.currency)+'</span></div>'+
 
-			'<div class="badge-link small" style="margin-bottom:10px">'+
-			'<span class="indicator '+color+'">Marketing Expense: '
-			+format_currency(info.marketing_expense, info.currency)+'</span></div>'+
-
 			'</div>').appendTo(frm.dashboard.stats_area_row);
+		if (frm.doc.doctype === 'Customer') {
+			$('<div class="badge-link small" style="margin-bottom:10px"><span class="indicator blue">'+
+			'Marketing Expense: '+info.marketing_expense+'</span></div>').appendTo(indicator);
+		}
 
 		if(info.loyalty_points){
 			$('<div class="badge-link small" style="margin-bottom:10px"><span class="indicator blue">'+

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -107,6 +107,8 @@ $.extend(erpnext.utils, {
 				frm.dashboard.add_indicator(__('Total Unpaid: {0}',
 					[format_currency(company_wise_info[0].total_unpaid, company_wise_info[0].currency)]),
 				company_wise_info[0].total_unpaid ? 'orange' : 'green');
+				frm.dashboard.add_indicator(__('Marketing Expense: {0}',
+					[format_currency(company_wise_info[0].marketing_expense, company_wise_info[0].currency)]), 'blue');
 
 				if(company_wise_info[0].loyalty_points) {
 					frm.dashboard.add_indicator(__('Loyalty Points: {0}',
@@ -133,6 +135,9 @@ $.extend(erpnext.utils, {
 			'<span class="indicator '+color+'">Total Unpaid: '
 			+format_currency(info.total_unpaid, info.currency)+'</span></div>'+
 
+			'<div class="badge-link small" style="margin-bottom:10px">'+
+			'<span class="indicator '+color+'">Marketing Expense: '
+			+format_currency(info.marketing_expense, info.currency)+'</span></div>'+
 
 			'</div>').appendTo(frm.dashboard.stats_area_row);
 

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -229,7 +229,7 @@
    "label": "Order Type",
    "oldfieldname": "order_type",
    "oldfieldtype": "Select",
-   "options": "\nSales\nMaintenance\nShopping Cart",
+   "options": "\nSales\nMaintenance\nShopping Cart\nMarketing",
    "print_hide": 1,
    "reqd": 1
   },
@@ -930,7 +930,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2019-12-30 19:14:56.630270",
+ "modified": "2020-07-15 03:24:10.684145",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -229,7 +229,7 @@
    "label": "Order Type",
    "oldfieldname": "order_type",
    "oldfieldtype": "Select",
-   "options": "\nSales\nMaintenance\nShopping Cart\nMarketing",
+   "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing",
    "print_hide": 1,
    "reqd": 1
   },
@@ -930,7 +930,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2020-07-15 03:24:10.684145",
+ "modified": "2020-07-16 01:27:03.276157",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -930,7 +930,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2020-07-16 01:27:03.276157",
+ "modified": "2020-07-16 06:14:56.179139",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -208,7 +208,7 @@
    "label": "Order Type",
    "oldfieldname": "order_type",
    "oldfieldtype": "Select",
-   "options": "\nSales\nMaintenance\nShopping Cart\nMarketing",
+   "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing",
    "print_hide": 1,
    "reqd": 1
   },
@@ -1232,7 +1232,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-15 03:28:28.114566",
+ "modified": "2020-07-16 01:47:12.785055",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -208,7 +208,7 @@
    "label": "Order Type",
    "oldfieldname": "order_type",
    "oldfieldtype": "Select",
-   "options": "\nSales\nMaintenance\nShopping Cart",
+   "options": "\nSales\nMaintenance\nShopping Cart\nMarketing",
    "print_hide": 1,
    "reqd": 1
   },
@@ -1232,7 +1232,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-02 23:12:33.920545",
+ "modified": "2020-07-15 03:28:28.114566",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1255,14 +1255,14 @@
    "fieldname": "order_type",
    "fieldtype": "Select",
    "label": "Order Type",
-   "options": "\nSales\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
+   "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-16 01:48:44.625428",
+ "modified": "2020-07-16 06:13:49.710494",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -13,6 +13,7 @@
   "naming_series",
   "customer",
   "customer_name",
+  "order_type",
   "column_break1",
   "amended_from",
   "company",
@@ -1249,13 +1250,19 @@
    "fieldtype": "Time",
    "label": "Deliver Before",
    "read_only": 1
+  },
+  {
+   "fieldname": "order_type",
+   "fieldtype": "Select",
+   "label": "Order Type",
+   "options": "Sales\nMarketing"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-02 23:15:08.846208",
+ "modified": "2020-07-15 03:33:09.200978",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1255,14 +1255,14 @@
    "fieldname": "order_type",
    "fieldtype": "Select",
    "label": "Order Type",
-   "options": "Sales\nMarketing"
+   "options": "\nSales\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-15 03:33:09.200978",
+ "modified": "2020-07-16 01:48:44.625428",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",


### PR DESCRIPTION
TASK ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01054. 

- [x] Create a new "Marketing" order type in the Sales Order doctype (and make sure it's fetched in the Order Desk) change to 
- Order Type Marketing added to Sales Invoice and Delivery Note


- [x] Track "Completed" Sales Order with the above order type and show it on the Customer dashboard, as shown below change to Paid Sales Invoice with Order Type Marketing track Marketing Expense
