### PR TITLE
feat: start and stop job card from work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -148,15 +148,15 @@ frappe.ui.form.on("Work Order", {
 			if(not_completed && not_completed.length) {
 				frm.add_custom_button(__('Create Job Card'), () => {
 					frm.trigger("make_job_card");
-				}).addClass('btn-primary');
+				},__('Job Card'));
 
 				frm.add_custom_button(__('Start Job Cards'), () => {
 					frm.trigger("start_job_cards");
-				}).addClass('btn-primary');
+				},__('Job Card'));
 
 				frm.add_custom_button(__('Stop Job Cards'), () => {
 					frm.trigger("stop_job_cards");
-				}).addClass('btn-primary');
+				},__('Job Card'));
 			}
 		}
 
@@ -277,15 +277,14 @@ frappe.ui.form.on("Work Order", {
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.work_order.work_order.start_job_cards",
 			args: {
-				name: frm.doc.name
+				work_order: frm.doc.name
 			},
 			freeze: true,
 			callback: (r) => {
-				console.log("message", r);
 				if(!r.message.length){
-					frappe.msgprint("There is nothing open job cards to start");
+					frappe.msgprint("There are no open Job Cards to start");
 				} else {
-					frappe.msgprint(__("Following job cards has been started {0}", [r.message.join("\n")]));
+					frappe.msgprint(__("The following job cards have been started:<br><ul><li>{0}</li></ul>", [r.message.join("<br><li>")]));
 				}
 			}
 		})
@@ -295,15 +294,14 @@ frappe.ui.form.on("Work Order", {
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.work_order.work_order.stop_job_cards",
 			args: {
-				name: frm.doc.name
+				work_order: frm.doc.name
 			},
 			freeze: true,
 			callback: (r) => {
-				console.log("message", r.message)
 				if(!r.message.length){
-					frappe.msgprint("There is nothing open job cards to stop");
+					frappe.msgprint("There are no open Job Cards to stop");
 				} else {
-					frappe.msgprint(__("Following job cards has been stopped {0}", [r.message.join("\n")]));
+					frappe.msgprint(__("The following job cards have been stopped: <br><ul><li>{0}</li></ul>", [r.message.join("<br><li>")]));
 				}
 			}
 		})

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -149,6 +149,14 @@ frappe.ui.form.on("Work Order", {
 				frm.add_custom_button(__('Create Job Card'), () => {
 					frm.trigger("make_job_card");
 				}).addClass('btn-primary');
+
+				frm.add_custom_button(__('Start Job Cards'), () => {
+					frm.trigger("start_job_cards");
+				}).addClass('btn-primary');
+
+				frm.add_custom_button(__('Stop Job Cards'), () => {
+					frm.trigger("stop_job_cards");
+				}).addClass('btn-primary');
 			}
 		}
 
@@ -263,6 +271,42 @@ frappe.ui.form.on("Work Order", {
 				}
 			});
 		}, __("For Job Card"));
+	},
+
+	start_job_cards: function(frm) {
+		frappe.call({
+			method: "erpnext.manufacturing.doctype.work_order.work_order.start_job_cards",
+			args: {
+				name: frm.doc.name
+			},
+			freeze: true,
+			callback: (r) => {
+				console.log("message", r);
+				if(!r.message.length){
+					frappe.msgprint("There is nothing open job cards to start");
+				} else {
+					frappe.msgprint(__("Following job cards has been started {0}", [r.message.join("\n")]));
+				}
+			}
+		})
+	},
+
+	stop_job_cards: function(frm) {
+		frappe.call({
+			method: "erpnext.manufacturing.doctype.work_order.work_order.stop_job_cards",
+			args: {
+				name: frm.doc.name
+			},
+			freeze: true,
+			callback: (r) => {
+				console.log("message", r.message)
+				if(!r.message.length){
+					frappe.msgprint("There is nothing open job cards to stop");
+				} else {
+					frappe.msgprint(__("Following job cards has been stopped {0}", [r.message.join("\n")]));
+				}
+			}
+		})
 	},
 
 	make_bom: function(frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -146,15 +146,15 @@ frappe.ui.form.on("Work Order", {
 			});
 
 			if(not_completed && not_completed.length) {
-				frm.add_custom_button(__('Create Job Card'), () => {
+				frm.add_custom_button(__('Create'), () => {
 					frm.trigger("make_job_card");
 				},__('Job Card'));
 
-				frm.add_custom_button(__('Start Job Cards'), () => {
+				frm.add_custom_button(__('Start All'), () => {
 					frm.trigger("start_job_cards");
 				},__('Job Card'));
 
-				frm.add_custom_button(__('Stop Job Cards'), () => {
+				frm.add_custom_button(__('Stop All'), () => {
 					frm.trigger("stop_job_cards");
 				},__('Job Card'));
 			}

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -814,20 +814,17 @@ def start_and_stop_job_cards(work_order, job_started=None):
 		}, ['name'])
 	for job_card in open_job_cards:
 		job = frappe.get_doc('Job Card', job_card)
+		job.job_started = job_started
 		if job_started == 1:
-			job.job_started = job_started
 			row = job.append('time_logs', {
 				"from_time": now_datetime(),
 				"completed_qty": 0
 			})
-			job.save()
-			job_cards.append(job.name)
 		elif job_started == 0:
-			job.job_started = job_started
 			for row in job.time_logs:
 				if not row.to_time:
 					row.to_time = now_datetime()
 					row.completed_qty = 0
-			job.save()
-			job_cards.append(job.name)
+		job.save()
+		job_cards.append(frappe.utils.get_link_to_form("Job Card", job.name))
 	return job_cards

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -818,13 +818,16 @@ def start_and_stop_job_cards(work_order, job_started=None):
 		job = frappe.get_doc('Job Card', job_card)
 		job.job_started = job_started
 		if job_started == True:
+			existing_from_time_count = 0
 			for row in job.time_logs:
 				if not row.to_time:
-					frappe.throw(_("Some Job Cards still in process. You can not start Job Cards."))
-			row = job.append('time_logs', {
-				"from_time": now_datetime(),
-				"completed_qty": 0
-			})
+					existing_from_time_count = existing_from_time_count + 1
+					continue
+			if not row_count:
+				row = job.append('time_logs', {
+					"from_time": now_datetime(),
+					"completed_qty": 0
+				})
 		elif job_started == False:
 			for row in job.time_logs:
 				if not row.to_time:

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -823,7 +823,7 @@ def start_and_stop_job_cards(work_order, job_started=None):
 				if not row.to_time:
 					existing_from_time_count = existing_from_time_count + 1
 					continue
-			if not row_count:
+			if not existing_from_time_count:
 				row = job.append('time_logs', {
 					"from_time": now_datetime(),
 					"completed_qty": 0


### PR DESCRIPTION
Task ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01048

Problem Statement: Need to start and stop all linked job cards from work order instead of going to each job card and start it manually.

Solution: 
![Peek 2020-07-18 20-25](https://user-images.githubusercontent.com/6947417/87855290-ea068680-c934-11ea-9a27-f7a0119affce.gif)
