### PR TITLE
fix: make fields mandatory for batch and serial no based on item

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -7,22 +7,8 @@ frappe.ui.form.on("Quality Inspection", {
 	item_code: function(frm) {
 		if (frm.doc.item_code) {
 			frappe.db.get_value('Item', {name: frm.doc.item_code}, ['has_batch_no','has_serial_no'], (r) => {
-				if (r.has_batch_no && r.has_serial_no) {
-					frm.toggle_reqd("batch_no", true);
-					frm.toggle_reqd("item_serial_no", true);
-				}
-				else if (r.has_batch_no && !r.has_serial_no) {
-					frm.toggle_reqd("batch_no", true);
-					frm.toggle_reqd("item_serial_no", false);
-				}
-				else if (!r.has_batch_no && r.has_serial_no) {
-					frm.toggle_reqd("batch_no", false);
-					frm.toggle_reqd("item_serial_no", true);
-				}
-				else {
-					frm.toggle_reqd("batch_no", false);
-					frm.toggle_reqd("item_serial_no", false);
-				}
+				frm.toggle_reqd("batch_no", r.has_batch_no);
+				frm.toggle_reqd("item_serial_no", r.has_serial_no);
 			});
 
 			return frm.call({

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -6,6 +6,25 @@ cur_frm.cscript.refresh = cur_frm.cscript.inspection_type;
 frappe.ui.form.on("Quality Inspection", {
 	item_code: function(frm) {
 		if (frm.doc.item_code) {
+			frappe.db.get_value('Item', {name: frm.doc.item_code}, ['has_batch_no','has_serial_no'], (r) => {
+				if (r.has_batch_no && r.has_serial_no) {
+					frm.toggle_reqd("batch_no", true);
+					frm.toggle_reqd("item_serial_no", true);
+				}
+				else if (r.has_batch_no && !r.has_serial_no) {
+					frm.toggle_reqd("batch_no", true);
+					frm.toggle_reqd("item_serial_no", false);
+				}
+				else if (!r.has_batch_no && r.has_serial_no) {
+					frm.toggle_reqd("batch_no", false);
+					frm.toggle_reqd("item_serial_no", true);
+				}
+				else {
+					frm.toggle_reqd("batch_no", false);
+					frm.toggle_reqd("item_serial_no", false);
+				}
+			});
+
 			return frm.call({
 				method: "get_quality_inspection_template",
 				doc: frm.doc,


### PR DESCRIPTION
https://bloomstack.com/desk#Form/Task/TASK-2020-01140

1. If Item has_batch_no checked then for QI make batch_no mandatory
2. if item has_serial_no checked then for QI make serial_no mandatory
3. if item has both has_serial_no and has_batch_no then for QI make both field mandatory  