### PR TITLE
feat: Delivery Note status auto updated

### DIFF
--- a/erpnext/patches/v13_0/update_delivery_note_status.py
+++ b/erpnext/patches/v13_0/update_delivery_note_status.py
@@ -1,0 +1,30 @@
+import frappe
+
+def execute():
+    notes = frappe.get_all("Delivery Note" , fields=["name", "delivered", "status"])
+    stops = frappe.get_all("Delivery Stop", fields=["visited", "sales_invoice", "delivery_note", "parent"])
+    for stop in stops:
+        if stop.visited:
+            for note in notes:
+                if stop.delivery_note == note.name:
+                    si_status = frappe.db.get_value("Sales Invoice", stop.sales_invoice, "status")
+                    if si_status == "Paid":
+                        frappe.db.set_value("Delivery Note", note.name ,{
+                            "delivered" : 1,
+                            "status" : "Completed"
+                        }, update_modified=False)
+                    if si_status == "Unpaid":
+                        frappe.db.set_value("Delivery Note", note.name ,{
+                            "delivered" : 1,
+                            "status" : "Delivered"
+                        }, update_modified=False)
+        else:
+             for note in notes:
+                if stop.delivery_note == note.name:
+                    dt_status = frappe.db.get_value("Delivery Trip", stop.parent, "status")
+                    if dt_status == "In Transit":
+                        frappe.db.set_value("Delivery Note", note.name ,{
+                            "delivered" : 0,
+                            "status" : "Out for Delivery"
+                        }, update_modified=False)
+

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -77,6 +77,11 @@ frappe.ui.form.on("Delivery Note", {
 
 
 	},
+	on_submit: (frm) => {
+		if (!frm.doc.delivered) {
+			frappe.db.set_value("Delivery Note", frm.doc.name, "status", "To Deliver")
+		}
+	},
 
 	print_without_amount: function(frm) {
 		erpnext.stock.delivery_note.set_print_hide(frm.doc);
@@ -91,6 +96,14 @@ frappe.ui.form.on("Delivery Note", {
 				})
 			}, __('Create'));
 			frm.page.set_inner_btn_group_as_primary(__('Create'));
+		}
+	},
+	delivered: function (frm) {
+		if (frm.doc.delivered) {
+			frm.set_value("status", "Delivered")
+		}
+		else {
+			frm.set_value("status", "To Deliver")
 		}
 	}
 });

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -19,10 +19,12 @@
   "company",
   "posting_date",
   "posting_time",
+  "delivered",
   "set_posting_time",
   "is_return",
   "issue_credit_note",
   "return_against",
+  "license",
   "customer_po_details",
   "po_no",
   "section_break_18",
@@ -1092,6 +1094,7 @@
    "label": "Status"
   },
   {
+   "allow_on_submit": 1,
    "default": "Draft",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -1100,7 +1103,7 @@
    "no_copy": 1,
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "\nDraft\nTo Bill\nCompleted\nCancelled\nClosed",
+   "options": "\nDraft\nTo Bill\nTo Deliver\nOut for Delivery\nDelivered\nCompleted\nCancelled\nClosed",
    "print_hide": 1,
    "print_width": "150px",
    "read_only": 1,
@@ -1256,13 +1259,27 @@
    "fieldtype": "Select",
    "label": "Order Type",
    "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "delivered",
+   "fieldtype": "Check",
+   "label": "Delivered ?"
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Link",
+   "label": "License",
+   "options": "Compliance Info"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-16 06:13:49.710494",
+ "modified": "2020-08-08 05:23:06.665088",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -12,7 +12,6 @@ import frappe.defaults
 from erpnext.controllers.selling_controller import SellingController
 from erpnext.stock.doctype.batch.batch import set_batch_nos
 from erpnext.stock.doctype.serial_no.serial_no import get_delivery_note_serial_no
-from erpnext.stock.doctype.delivery_trip.delivery_trip import get_delivery_window
 from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
 from frappe.desk.notifications import clear_doctype_notifications
@@ -553,6 +552,7 @@ def make_delivery_trip(source_name, target_doc=None):
 		target.package_total = sum([stop.grand_total for stop in target.delivery_stops if stop.grand_total])
 
 	def update_stop_details(source_doc, target_doc, source_parent):
+		from erpnext.stock.doctype.delivery_trip.delivery_trip import get_delivery_window
 		delivery_window = get_delivery_window(source_parent.doctype, source_parent.name)
 		target_doc.delivery_start_time = delivery_window.delivery_start_time
 		target_doc.delivery_end_time = delivery_window.delivery_end_time

--- a/erpnext/stock/doctype/delivery_stop/delivery_stop.json
+++ b/erpnext/stock/doctype/delivery_stop/delivery_stop.json
@@ -13,8 +13,11 @@
   "visited",
   "order_information_section",
   "delivery_note",
+  "sales_invoice",
   "cb_order",
   "grand_total",
+  "paid_amount",
+  "make_payment_entry",
   "section_break_7",
   "contact",
   "email_sent_to",
@@ -206,11 +209,31 @@
    "fieldtype": "Time",
    "label": "Delivery End Time",
    "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoice",
+   "fieldtype": "Link",
+   "label": "Sales Invoice",
+   "options": "Sales Invoice",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "make_payment_entry",
+   "fieldtype": "Button",
+   "label": "Make Payment Entry"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-03-24 01:27:18.124556",
+ "modified": "2020-08-05 05:22:14.527258",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Stop",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -41,6 +41,54 @@ frappe.ui.form.on('Delivery Trip', {
 	},
 
 	refresh: function (frm) {
+		if (frm.doc.docstatus == 1 && frm.doc.status != "Completed") {
+			if (frm.doc.status == "Scheduled") {
+				frm.trigger("start");
+			} else if (frm.doc.status == "In Transit") {
+				frm.trigger("pause");
+				frm.trigger("end");
+			} else if (frm.doc.status == "Paused") {
+				frm.trigger("continue");
+				frm.trigger("end");
+			}
+		}
+
+		frappe.db.get_value("Google Settings", { name: "Google Settings" }, "enable", (r) => {
+			if (r.enable == 0) {
+				// Hide entire Map section if Google Maps is disabled
+				let wrapper = frm.fields_dict.sb_map.wrapper;
+				wrapper.hide();
+			} else {
+				// Inject Google Maps data into map embed field
+				let wrapper = frm.fields_dict.map_html.$wrapper;
+				wrapper.html(frm.doc.map_embed);
+			}
+		});
+
+		// Print delivery manifests
+		if (frm.doc.docstatus === 1) {
+			if (frm.doc.delivery_stops.length > 0) {
+				let deliveryNotes = frm.doc.delivery_stops.map(stop => stop.delivery_note);
+				deliveryNotes = [...new Set(deliveryNotes)];
+				deliveryNotes = deliveryNotes.filter(Boolean);
+
+				frm.add_custom_button(__("Print Shipping Manifests"), () => {
+					if (deliveryNotes.length == 0) {
+						frappe.msgprint(__("There are no Delivery Notes linked to any stop(s)"))
+					} else {
+						const w = window.open('/api/method/frappe.utils.print_format.download_multi_pdf?' +
+							'doctype=' + encodeURIComponent("Delivery Note") +
+							'&name=' + encodeURIComponent(JSON.stringify(deliveryNotes)) +
+							'&format=' + encodeURIComponent(frm.doc.shipping_manifest_template || ""));
+
+						if (!w) {
+							frappe.msgprint(__('Please enable pop-ups'));
+							return;
+						}
+					}
+				}).addClass("btn-primary");
+			};
+		}
 		if (frm.doc.docstatus == 1 && frm.doc.delivery_stops.length > 0) {
 			frm.add_custom_button(__("Notify Customers via Email"), function () {
 				frm.trigger('notify_customers');
@@ -64,6 +112,125 @@ frappe.ui.form.on('Delivery Trip', {
 				})
 			}, __("Get customers from"));
 		}
+	},
+
+	force_save_or_update: function (frm, cdt, cdn) {
+		// `model.set_value` doesn't trigger a form change, so
+		// force-dirty to allow the form to be saved or updated
+		frm.dirty();
+		frm.save_or_update();
+	},
+
+	start: (frm) => {
+		frm.add_custom_button(__("Start"), () => {
+			frappe.db.get_value("Delivery Settings", { "name": "Delivery Settings" }, "default_activity_type")
+				.then((r) => {
+					if (!r.message.default_activity_type) {
+						frappe.throw(__("Please set a default activity type in Delivery Settings to time this trip."));
+						return;
+					} else {
+						frappe.prompt({
+							"label": "Odometer Start Value",
+							"fieldtype": "Int",
+							"fieldname": "odometer_start_value",
+							"reqd": 1
+						},
+							(data) => {
+								frappe.call({
+									method: "erpnext.stock.doctype.delivery_trip.delivery_trip.create_or_update_timesheet",
+									args: {
+										"trip": frm.doc.name,
+										"action": "start",
+										"odometer_value": data.odometer_start_value,
+									},
+									callback: (r) => {
+										frm.reload_doc();
+									}
+								})
+								for(let stops of frm.doc.delivery_stops){
+									frappe.db.set_value("Delivery Note", stops.delivery_note, "status", "Out for Delivery")
+								}
+							},
+							__("Enter Odometer Value"));
+					}
+				})
+		}).addClass("btn-primary");
+	},
+
+	pause: (frm) => {
+		frm.add_custom_button(__("Pause"), () => {
+			frappe.confirm(__("Are you sure you want to pause the trip?"),
+				() => {
+					frappe.call({
+						method: "erpnext.stock.doctype.delivery_trip.delivery_trip.create_or_update_timesheet",
+						args: {
+							"trip": frm.doc.name,
+							"action": "pause"
+						},
+						callback: (r) => {
+							frm.reload_doc();
+						}
+					})
+				},
+				() => {
+					frm.reload_doc();
+				}
+			);
+
+		}).addClass("btn-primary");
+	},
+
+	continue: (frm) => {
+		frm.add_custom_button(__("Continue"), () => {
+			frappe.confirm(__("Are you sure you want to continue the trip?"),
+				() => {
+					frappe.call({
+						method: "erpnext.stock.doctype.delivery_trip.delivery_trip.create_or_update_timesheet",
+						args: {
+							"trip": frm.doc.name,
+							"action": "continue"
+						},
+						callback: (r) => {
+							frm.reload_doc();
+						}
+					})
+				},
+				() => {
+					frm.reload_doc();
+				}
+			);
+
+		}).addClass("btn-primary");
+	},
+
+	end: (frm) => {
+		frm.add_custom_button(__("End"), () => {
+			frappe.prompt({
+				"label": "Odometer End Value",
+				"fieldtype": "Int",
+				"fieldname": "odometer_end_value",
+				"reqd": 1,
+				"default": frm.doc.odometer_start_value
+			},
+				(data) => {
+					frappe.call({
+						method: "erpnext.stock.doctype.delivery_trip.delivery_trip.create_or_update_timesheet",
+						args: {
+							"trip": frm.doc.name,
+							"action": "end",
+							"odometer_value": data.odometer_end_value,
+						},
+						callback: (r) => {
+							frm.reload_doc();
+						}
+					})
+				},
+				__("Enter Odometer Value"));
+		}).addClass("btn-primary");
+	},
+
+	before_submit: function (frm) {
+		frm.toggle_reqd(["driver", "driver_address"], 1)
 	},
 
 	validate: function (frm) {
@@ -271,5 +438,80 @@ frappe.ui.form.on('Delivery Stop', {
 		} else {
 			frappe.model.set_value(cdt, cdn, "customer_contact", "");
 		}
+	},
+
+	visited: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (row.visited) {
+			frappe.db.get_value("Sales Invoice", row.sales_invoice, "status")
+				.then(status => {
+					frappe.db.set_value("Delivery Note", row.delivery_note, "delivered", 1)
+					if (status.message.status === "Unpaid") {
+						frappe.db.set_value("Delivery Note", row.delivery_note, "status", "Delivered")
+					}
+					if (status.message.status === "Paid") {
+						frappe.db.set_value("Delivery Note", row.delivery_note, "status", "Completed")
+					}
+				})
+		}
+
+		if (row.visited && row.sales_invoice) {
+			if (row.paid_amount !== row.grand_total) {
+				frappe.call({
+					method: "erpnext.stock.doctype.delivery_trip.delivery_trip.update_payment_due_date",
+					args: {
+						sales_invoice: row.sales_invoice
+					}
+				})
+			}
+		}
+	},
+
+	make_payment_entry: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+
+		let dialog = frappe.prompt({
+			"label": "Payment Amount",
+			"fieldtype": "Currency",
+			"fieldname": "payment_amount",
+			"reqd": 1
+		},
+			function (data) {
+				if (data.payment_amount === 0) {
+					frappe.confirm(
+						__("Are you sure you want to complete this delivery without a payment?"),
+						() => {
+							frappe.model.set_value(cdt, cdn, "visited", true);
+							frappe.model.set_value(cdt, cdn, "paid_amount", 0);
+							frappe.db.set_value("Delivery Note", row.delivery_note, "status", "Completed")
+							frm.trigger("force_save_or_update");
+						}
+					);
+				} else {
+					frappe.call({
+						method: "erpnext.stock.doctype.delivery_trip.delivery_trip.make_payment_entry",
+						args: {
+							"payment_amount": data.payment_amount,
+							"sales_invoice": row.sales_invoice
+						},
+						callback: function (r) {
+							if (!r.exc) {
+								frappe.msgprint(__(`Payment Entry ${r.message} created.`));
+								frappe.model.set_value(cdt, cdn, "visited", true);
+								frappe.model.set_value(cdt, cdn, "paid_amount", data.payment_amount);
+								frappe.db.set_value("Delivery Note", row.delivery_note, "status", "Completed")
+								frm.trigger("force_save_or_update");
+							}
+						}
+					})
+				}
+			},
+			__("Make Payment Entry"));
+
+		dialog.$wrapper.on("shown.bs.modal", function () {
+			if (frappe.is_mobile()) {
+				dialog.$wrapper.find($('input[data-fieldtype="Currency"]')).attr('type', 'number');
+			}
+		});
 	}
 });

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.json
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.json
@@ -22,10 +22,20 @@
   "column_break_4",
   "vehicle",
   "departure_time",
+  "odometer",
+  "odometer_start_value",
+  "odometer_start_time",
+  "actual_distance_travelled",
+  "column_break_17",
+  "odometer_end_value",
+  "odometer_end_time",
   "delivery_service_stops",
   "delivery_stops",
   "calculate_arrival_time",
   "optimize_route",
+  "sb_map",
+  "map_html",
+  "map_embed",
   "section_break_15",
   "status",
   "cb_more_info",
@@ -184,11 +194,71 @@
    "fieldtype": "Currency",
    "label": "Package Total",
    "read_only": 1
+  },
+  {
+   "fieldname": "odometer",
+   "fieldtype": "Section Break",
+   "label": "Odometer"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "odometer_start_value",
+   "fieldtype": "Int",
+   "label": "Odometer Start Value",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "odometer_start_time",
+   "fieldtype": "Datetime",
+   "label": "Odometer Start Time",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "actual_distance_travelled",
+   "fieldtype": "Int",
+   "label": "Actual Distance Travelled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_17",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "odometer_end_value",
+   "fieldtype": "Int",
+   "label": "Odometer End Value",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "odometer_end_time",
+   "fieldtype": "Datetime",
+   "label": "Odometer End Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sb_map",
+   "fieldtype": "Section Break",
+   "label": "Map"
+  },
+  {
+   "fieldname": "map_html",
+   "fieldtype": "HTML",
+   "label": "Map"
+  },
+  {
+   "fieldname": "map_embed",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Map Embed"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-01-26 22:37:14.824021",
+ "modified": "2020-08-05 05:02:38.250830",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Trip",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -9,9 +9,11 @@ import json
 
 import frappe
 from frappe import _
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+from erpnext.accounts.party import get_due_date
 from frappe.contacts.doctype.address.address import get_address_display
 from frappe.model.document import Document
-from frappe.utils import cint, get_datetime, get_link_to_form
+from frappe.utils import cint, get_datetime, get_link_to_form, flt
 
 
 class DeliveryTrip(Document):
@@ -92,6 +94,10 @@ class DeliveryTrip(Document):
 			for field, value in update_fields.items():
 				value = None if delete else value
 				setattr(note_doc, field, value)
+
+			if delete:
+				setattr(note_doc, "delivered", 0)
+				setattr(note_doc, "status", "To Deliver")
 
 			note_doc.flags.ignore_validate_update_after_submit = True
 			note_doc.save()
@@ -456,3 +462,100 @@ def get_driver_email(driver):
 	employee = frappe.db.get_value("Driver", driver, "employee")
 	email = frappe.db.get_value("Employee", employee, "prefered_email")
 	return {"email": email}
+
+@frappe.whitelist()
+def create_or_update_timesheet(trip, action, odometer_value=None):
+	delivery_trip = frappe.get_doc("Delivery Trip", trip)
+	time = frappe.utils.now()
+
+	def get_timesheet():
+		timesheet_list = frappe.get_all("Timesheet", filters={'docstatus': 0, 'delivery_trip': delivery_trip.name})
+		if timesheet_list:
+			return frappe.get_doc("Timesheet", timesheet_list[0].name)
+
+	if action == "start":
+		employee = frappe.get_value("Driver", delivery_trip.driver, "employee")
+		timesheet = frappe.new_doc("Timesheet")
+		timesheet.company = delivery_trip.company
+		timesheet.employee = employee
+		timesheet.delivery_trip = delivery_trip.name
+		timesheet.append("time_logs", {
+			"from_time": time,
+			"activity_type": frappe.db.get_single_value("Delivery Settings", "default_activity_type")
+		})
+		timesheet.save()
+
+		frappe.db.set_value("Delivery Trip", trip, "status", "In Transit", update_modified=False) # Because we can't status as allow on submit
+		frappe.db.set_value("Delivery Trip", trip, "odometer_start_value", odometer_value, update_modified=False)
+		frappe.db.set_value("Delivery Trip", trip, "odometer_start_time", time, update_modified=False)
+	elif action == "pause":
+		timesheet = get_timesheet()
+
+		if timesheet and len(timesheet.time_logs) > 0:
+			last_timelog = timesheet.time_logs[-1]
+
+			if last_timelog.activity_type == frappe.db.get_single_value("Delivery Settings", "default_activity_type"):
+				if last_timelog.from_time and not last_timelog.to_time:
+					last_timelog.to_time = time
+					timesheet.save()
+
+		frappe.db.set_value("Delivery Trip", trip, "status", "Paused", update_modified=False)
+	elif action == "continue":
+		timesheet = get_timesheet()
+
+		if timesheet and len(timesheet.time_logs) > 0:
+			last_timelog = timesheet.time_logs[-1]
+
+			if last_timelog.activity_type == frappe.db.get_single_value("Delivery Settings", "default_activity_type"):
+				if last_timelog.from_time and last_timelog.to_time:
+					timesheet.append("time_logs", {
+						"from_time": time,
+						"activity_type": frappe.db.get_single_value("Delivery Settings", "default_activity_type")
+					})
+					timesheet.save()
+
+		frappe.db.set_value("Delivery Trip", trip, "status", "In Transit", update_modified=False)
+	elif action == "end":
+		timesheet = get_timesheet()
+
+		if timesheet and len(timesheet.time_logs) > 0:
+			last_timelog = timesheet.time_logs[-1]
+
+			if last_timelog.activity_type == frappe.db.get_single_value("Delivery Settings", "default_activity_type"):
+				last_timelog.to_time = time
+				timesheet.save()
+				timesheet.submit()
+
+		frappe.db.set_value("Delivery Trip", trip, "status", "Completed", update_modified=False)
+		frappe.db.set_value("Delivery Trip", trip, "odometer_end_value", odometer_value, update_modified=False)
+		frappe.db.set_value("Delivery Trip", trip, "odometer_end_time", time, update_modified=False)
+
+		start_value = frappe.db.get_value("Delivery Trip", trip, "odometer_start_value")
+		frappe.db.set_value("Delivery Trip", trip, "actual_distance_travelled", flt(odometer_value) - start_value, update_modified=False)
+
+@frappe.whitelist()
+def make_payment_entry(payment_amount, sales_invoice):
+	payment_entry = get_payment_entry("Sales Invoice", sales_invoice, party_amount=flt(payment_amount))
+	payment_entry.paid_amount = payment_amount
+	payment_entry.reference_date = today()
+	payment_entry.reference_no = sales_invoice
+	payment_entry.flags.ignore_permissions = True
+	payment_entry.save()
+
+	return payment_entry.name
+
+@frappe.whitelist()
+def update_payment_due_date(sales_invoice):
+	invoice = frappe.get_doc("Sales Invoice", sales_invoice)
+
+	if not invoice.payment_terms_template:
+		return
+
+	due_date = get_due_date(invoice.posting_date, "Customer", invoice.customer, bill_date=frappe.utils.add_days(nowdate(), 7))
+
+	# Update due date in both parent and child documents
+	invoice.due_date = due_date
+	for term in invoice.payment_schedule:
+		term.due_date = due_date
+
+	invoice.save()


### PR DESCRIPTION
https://bloomstack.com/desk#Form/Task/TASK-2020-00688

1.If Delivered? Is set in Delivery Note, the status changes to "Delivered"
2. If Delivered? is not set the updated status "To Deliver"
![2DN_Delivered](https://user-images.githubusercontent.com/58166671/89768582-685fde00-db19-11ea-84bf-173a2ab3eab8.gif)


3. If Delivery Trip is created and Started then Delivery Note status changes  to "Out for Delivery"
![4DT_start](https://user-images.githubusercontent.com/58166671/89769101-3a2ece00-db1a-11ea-9ae3-810dc54f27ee.gif)


4. If "Visited" is checked in Delivery Trip, It check for Payment is made against Sales Invoice
4.1 If Sales Invoice status is "Unpaid" then Delivery Note status changes to "Delivered"
![5DT_Visited](https://user-images.githubusercontent.com/58166671/89769496-d78a0200-db1a-11ea-8eae-94470aeeb9cc.gif)


4.2 If Sales Invoice Status Is "Paid" then Delivery Note Status Changed to "Completed"
![6DN_completed](https://user-images.githubusercontent.com/58166671/89770200-0d7bb600-db1c-11ea-9245-ff24f2c4f86d.gif)


5. If Delivery Trip cancelled then Delivery Note status Changes back to "To Delivery"
![7DT_cancel](https://user-images.githubusercontent.com/58166671/89769729-48311e80-db1b-11ea-91ea-379435fc0a53.gif)
