### PR TITLE
feat(stock): added coa to batch and delivery note item

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -92,6 +92,23 @@ frappe.ui.form.on("Delivery Note", {
 			}, __('Create'));
 			frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
+	},
+
+	email_coas: function(frm) {
+		frappe.call({
+			method: "erpnext.stock.doctype.delivery_note.delivery_note.email_coas",
+			args: {
+				docname: frm.doc.name
+			},
+			callback: (r) => {
+				if(r.message == "success"){
+					frappe.show_alert({
+						indicator: 'green',
+						message: __('Email Queued')
+					});
+				}
+			}
+		})
 	}
 });
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-24 19:29:09",
@@ -57,6 +56,7 @@
   "items_section",
   "scan_barcode",
   "items",
+  "email_coas",
   "pricing_rule_details",
   "pricing_rules",
   "packing_list",
@@ -1252,13 +1252,18 @@
    "fieldtype": "Select",
    "label": "Order Type",
    "options": "\nSales\nMaintenance\nShopping Cart\nPromotional\nSample\nPAD\nWarranty\nConsignment\nReplenishment\nMarketing"
+  },
+  {
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "email_coas",
+   "fieldtype": "Button",
+   "label": "Email CoAs"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
- "links": [],
- "modified": "2020-07-16 06:13:49.710494",
+ "modified": "2020-08-14 04:32:05.975786",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1257,13 +1257,13 @@
    "depends_on": "eval:doc.docstatus==1",
    "fieldname": "email_coas",
    "fieldtype": "Button",
-   "label": "Email CoAs"
+   "label": "Email Certificates of Analysis"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
- "modified": "2020-08-14 04:32:05.975786",
+ "modified": "2020-08-14 05:17:18.750711",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -648,11 +648,8 @@ def email_coas(docname):
 
 	attachments = []
 	for item in delivery_note.get("items"):
-		coa = frappe.db.get_value("File", {"file_url": item.certificate_of_analysis},
-			["name", "attached_to_doctype", "attached_to_name"], as_dict = 1)
-		attachments.append({
-			"fid": coa.name
-		})
+		coa_file_id = frappe.db.get_value("File", {"file_url": item.certificate_of_analysis}, "name")
+		attachments.append({"fid": coa_file_id})
 
 	frappe.sendmail(recipients = delivery_note.get("contact_email"), subject = "Certificate of Analysis" , attachments = attachments)
 	status = "success"

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -117,6 +117,7 @@ class DeliveryNote(SellingController):
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_with_previous_doc()
+		self.validate_batch_coa()
 
 		if self._action != 'submit' and not self.is_return:
 			set_batch_nos(self, 'warehouse', True)

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -157,6 +157,12 @@ class DeliveryNote(SellingController):
 			self.validate_rate_with_reference_doc([["Sales Order", "against_sales_order", "so_detail"],
 				["Sales Invoice", "against_sales_invoice", "si_detail"]])
 
+	def validate_batch_coa(self):
+		for item in self.items:
+			if item.batch_no:
+				coa = frappe.db.get_value("Batch", item.batch_no, "certificate_of_analysis")
+				item.certificate_of_analysis = coa
+
 	def validate_proj_cust(self):
 		"""check for does customer belong to same project as entered.."""
 		if self.project and self.customer:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -161,8 +161,7 @@ class DeliveryNote(SellingController):
 	def validate_batch_coa(self):
 		for item in self.items:
 			if item.batch_no:
-				coa = frappe.db.get_value("Batch", item.batch_no, "certificate_of_analysis")
-				item.certificate_of_analysis = coa
+				item.certificate_of_analysis = frappe.db.get_value("Batch", item.batch_no, "certificate_of_analysis")
 
 	def validate_proj_cust(self):
 		"""check for does customer belong to same project as entered.."""

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -726,16 +726,15 @@
    "label": "Ignore Pricing Rule"
   },
   {
-<<<<<<< HEAD
    "fieldname": "package_tag",
    "fieldtype": "Link",
    "label": "Package Tag",
    "options": "Package Tag"
-=======
+  },
+  {
    "fieldname": "certificate_of_analysis",
    "fieldtype": "Attach",
    "label": "Certificate of Analysis"
->>>>>>> c72f6b4b4a... WIP
   }
  ],
  "idx": 1,

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -74,6 +74,7 @@
   "actual_batch_qty",
   "actual_qty",
   "installed_qty",
+  "certificate_of_analysis",
   "item_tax_rate",
   "accounting_details_section",
   "expense_account",
@@ -725,15 +726,22 @@
    "label": "Ignore Pricing Rule"
   },
   {
+<<<<<<< HEAD
    "fieldname": "package_tag",
    "fieldtype": "Link",
    "label": "Package Tag",
    "options": "Package Tag"
+=======
+   "fieldname": "certificate_of_analysis",
+   "fieldtype": "Attach",
+   "label": "Certificate of Analysis"
+>>>>>>> c72f6b4b4a... WIP
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-08-06 04:09:38.298411",
+ "links": [],
+ "modified": "2020-08-10 22:54:07.086825",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -734,13 +734,13 @@
   {
    "fieldname": "certificate_of_analysis",
    "fieldtype": "Attach",
-   "label": "Certificate of Analysis"
+   "label": "Certificate of Analysis",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "links": [],
- "modified": "2020-08-10 22:54:07.086825",
+ "modified": "2020-08-11 06:38:45.146109",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -157,6 +157,27 @@ frappe.ui.form.on('Delivery Trip', {
 				});
 			}
 		});
+	},
+
+	email_coas: function(frm) {
+		let delivery_notes = frm.doc.delivery_stops.map(stop => stop.delivery_note);
+		delivery_notes = [...new Set(delivery_notes)];
+		delivery_notes.forEach(delivery_note =>{
+			frappe.call({
+				method: "erpnext.stock.doctype.delivery_note.delivery_note.email_coas",
+				args: {
+					docname: delivery_note
+				},
+				callback: (r) => {
+					if(r.message == "success"){
+						frappe.show_alert({
+							indicator: 'green',
+							message: __('Email Queued')
+						});
+					}
+				}
+			})
+		})
 	}
 });
 

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.json
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.json
@@ -23,6 +23,7 @@
   "departure_time",
   "delivery_service_stops",
   "delivery_stops",
+  "email_coas",
   "calculate_arrival_time",
   "optimize_route",
   "section_break_15",
@@ -183,10 +184,16 @@
    "options": "Delivery Trip",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "email_coas",
+   "fieldtype": "Button",
+   "label": "Email CoAs"
   }
  ],
  "is_submittable": 1,
- "modified": "2020-06-10 07:06:57.935453",
+ "modified": "2020-08-14 04:30:57.313683",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Trip",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.json
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.json
@@ -189,11 +189,11 @@
    "depends_on": "eval:doc.docstatus==1",
    "fieldname": "email_coas",
    "fieldtype": "Button",
-   "label": "Email CoAs"
+   "label": "Email Certificates of Analysis"
   }
  ],
  "is_submittable": 1,
- "modified": "2020-08-14 04:30:57.313683",
+ "modified": "2020-08-14 05:18:24.767202",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Trip",

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -92,6 +92,16 @@ frappe.ui.form.on("Quality Inspection", {
 				frm.set_value("batch_no", r.batch_no);
 			});
 		}
+	},
+	before_save: (frm) => {
+		if (frm.doc.item_code) {
+			frappe.db.get_value("Compliance Item", { "item_code": frm.doc.item_code }, "item_code")
+			.then(item => {
+				if(frm.doc.inspection_by == "External"){
+					frm.toggle_reqd('certificate_of_analysis', !!item.message);
+				}
+			})
+		}
 	}
 })
 

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -95,12 +95,13 @@ frappe.ui.form.on("Quality Inspection", {
 	},
 	before_save: (frm) => {
 		if (frm.doc.item_code) {
-			frappe.db.get_value("Compliance Item", { "item_code": frm.doc.item_code }, "item_code")
-			.then(item => {
-				if(frm.doc.inspection_by == "External"){
-					frm.toggle_reqd('certificate_of_analysis', !!item.message);
-				}
-			})
+			if(frm.doc.inspection_by == "External"){
+				frappe.db.get_value("Compliance Item", { "item_code": frm.doc.item_code }, "item_code")
+				.then(item => {
+						frm.toggle_reqd('certificate_of_analysis', !!item.message);
+					
+				})
+			}
 		}
 	}
 })

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -94,14 +94,14 @@ frappe.ui.form.on("Quality Inspection", {
 		}
 	},
 	before_save: (frm) => {
-		if (frm.doc.item_code) {
-			if(frm.doc.inspection_by == "External"){
-				frappe.db.get_value("Compliance Item", { "item_code": frm.doc.item_code }, "item_code")
-				.then(item => {
-						frm.toggle_reqd('certificate_of_analysis', !!item.message);
-					
-				})
-			}
+		if (frm.doc.item_code && frm.doc.inspection_by == "External") {
+			frappe.db.get_value("Compliance Item", { "item_code": frm.doc.item_code }, "item_code")
+			.then(item => {
+					frm.toggle_reqd('certificate_of_analysis', !!item.message);
+			})
+		}
+		else {
+			frm.toggle_reqd('certificate_of_analysis', 0);
 		}
 	}
 })

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -12,7 +12,7 @@ class QualityInspection(Document):
 	def validate(self):
 		if not self.readings and self.item_code:
 			self.get_item_specification_details()
-		self.validate_certificate_of_analysis()
+		
 
 	def get_item_specification_details(self):
 		if not self.quality_inspection_template:
@@ -47,6 +47,7 @@ class QualityInspection(Document):
 
 	def on_submit(self):
 		self.update_qc_reference()
+		self.validate_certificate_of_analysis()
 		if self.batch_no:
 			self.set_batch_coa()
 

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -45,9 +45,11 @@ class QualityInspection(Document):
 		self.quality_inspection_template = template
 		self.get_item_specification_details()
 
+	def before_submit(self):
+		self.validate_certificate_of_analysis()
+
 	def on_submit(self):
 		self.update_qc_reference()
-		self.validate_certificate_of_analysis()
 		if self.batch_no:
 			self.set_batch_coa()
 

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -30,10 +30,9 @@ class QualityInspection(Document):
 			child.status = "Accepted"
 
 	def validate_certificate_of_analysis(self):
-		ci = frappe.db.get_value("Compliance Item", self.item_code, "item_code")
-		if ci and self.inspection_by == "External":
-			if not self.certificate_of_analysis:
-				frappe.throw(_("Please attach CoA"))
+		compliance_item = frappe.db.exists("Compliance Item", self.item_code)
+		if compliance_item and self.inspection_by == "External" and not self.certificate_of_analysis:
+			frappe.throw(_("Please attach a Certificate of Analysis"))
 
 	def get_quality_inspection_template(self):
 		template = ''


### PR DESCRIPTION
[Task](https://bloomstack.com/desk#Form/Task/TASK-2020-00070)

<hr>

Quality Inspection:
- [x] On the client-side, make the field mandatory of the selected item has a Compliance Item record, and the Inspection By is External
- [x] On the server-side, validate that a CoA should be attached if the selected item has a Compliance Item record, and the Inspection By is External

Batch:
- [x] If a Quality Inspection is submitted with a CoA, then attach the same file in Batch (do not re-attach, just refer to the file in Quality Inspection instead)

Delivery Note Item:
- [x] If an item batch is selected that has an attached CoA, then attach the same file in that Delivery Note Item row (do not re-attach, just refer to the file in Quality Inspection instead)

Delivery Note:
- [x] Add a button in Delivery Note called Email CoAs to allow mass-emailing all the CoAs attached to the items in the document, to the primary contact of the customer
- [x] If no CoAs are found, show a message to the user

Delivery Trip:
- [x] Add a button in Delivery Trip called Email CoAs to allow mass-emailing all the CoAs attached to all the items in the linked Delivery Notes, to the primary contacts of each customer in the trip
- [x] If no CoAs are found, show a message to the user