### PR TITLE
fix: change title based on party name in multiple transactions

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -56,9 +56,12 @@ class PurchaseInvoice(BuyingController):
 		if not self.on_hold:
 			self.release_date = ''
 
-
 	def invoice_is_blocked(self):
 		return self.on_hold and (not self.release_date or self.release_date > getdate(nowdate()))
+	
+	def on_update(self):
+		self.title = self.supplier
+		frappe.db.set_value("Purchase Invoice",self.name,'title',self.supplier)
 
 	def validate(self):
 		if not self.is_opening:

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -58,12 +58,10 @@ class PurchaseInvoice(BuyingController):
 
 	def invoice_is_blocked(self):
 		return self.on_hold and (not self.release_date or self.release_date > getdate(nowdate()))
-	
-	def on_update(self):
-		self.title = self.supplier
-		frappe.db.set_value("Purchase Invoice",self.name,'title',self.supplier)
 
 	def validate(self):
+		self.set_title()
+
 		if not self.is_opening:
 			self.is_opening = 'No'
 
@@ -105,6 +103,9 @@ class PurchaseInvoice(BuyingController):
 		self.set_status()
 		self.validate_purchase_receipt_if_update_stock()
 		validate_inter_company_party(self.doctype, self.supplier, self.company, self.inter_company_invoice_reference)
+
+	def set_title(self):
+		self.title = self.supplier
 
 	def validate_release_date(self):
 		if self.release_date and getdate(nowdate()) >= getdate(self.release_date):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -372,6 +372,8 @@ class SalesInvoice(SellingController):
 				data.sales_invoice = sales_invoice
 
 	def on_update(self):
+		self.title = self.customer
+		frappe.db.set_value("Sales Invoice",self.name,'title',self.customer)
 		self.set_paid_amount()
 
 	def set_paid_amount(self):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -77,6 +77,7 @@ class SalesInvoice(SellingController):
 		if not self.is_pos:
 			self.so_dn_required()
 
+		self.set_title()
 		self.validate_proj_cust()
 		self.validate_pos_return()
 		self.validate_with_previous_doc()
@@ -371,10 +372,8 @@ class SalesInvoice(SellingController):
 				(not sales_invoice and data.sales_invoice == self.name):
 				data.sales_invoice = sales_invoice
 
-	def on_update(self):
+	def set_title(self):
 		self.title = self.customer
-		frappe.db.set_value("Sales Invoice",self.name,'title',self.customer)
-		self.set_paid_amount()
 
 	def set_paid_amount(self):
 		paid_amount = 0.0

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -375,6 +375,9 @@ class SalesInvoice(SellingController):
 	def set_title(self):
 		self.title = self.customer
 
+	def on_update(self):
+		self.set_paid_amount()
+
 	def set_paid_amount(self):
 		paid_amount = 0.0
 		base_paid_amount = 0.0

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -39,15 +39,12 @@ class PurchaseOrder(BuyingController):
 			'percent_join_field': 'material_request'
 		}]
 	
-	def on_update(self):
-		self.title = self.supplier
-		frappe.db.set_value("Purchase Order",self.name,'title',self.supplier)
-
 	def validate(self):
 		super(PurchaseOrder, self).validate()
 
 		self.set_status()
 
+		self.set_title()
 		self.validate_supplier()
 		self.validate_schedule_date()
 		validate_for_items(self)
@@ -90,6 +87,9 @@ class PurchaseOrder(BuyingController):
 
 		if cint(frappe.db.get_single_value('Buying Settings', 'maintain_same_rate')):
 			self.validate_rate_with_reference_doc([["Supplier Quotation", "supplier_quotation", "supplier_quotation_item"]])
+
+	def set_title(self):
+		self.title = self.supplier
 
 	def validate_supplier(self):
 		prevent_po = frappe.db.get_value("Supplier", self.supplier, 'prevent_pos')

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -88,6 +88,9 @@ class PurchaseOrder(BuyingController):
 		if cint(frappe.db.get_single_value('Buying Settings', 'maintain_same_rate')):
 			self.validate_rate_with_reference_doc([["Supplier Quotation", "supplier_quotation", "supplier_quotation_item"]])
 
+	def on_update(self):
+		pass
+
 	def set_title(self):
 		self.title = self.supplier
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -38,7 +38,7 @@ class PurchaseOrder(BuyingController):
 			'source_field': 'stock_qty',
 			'percent_join_field': 'material_request'
 		}]
-	
+
 	def validate(self):
 		super(PurchaseOrder, self).validate()
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -38,6 +38,10 @@ class PurchaseOrder(BuyingController):
 			'source_field': 'stock_qty',
 			'percent_join_field': 'material_request'
 		}]
+	
+	def on_update(self):
+		self.title = self.supplier
+		frappe.db.set_value("Purchase Order",self.name,'title',self.supplier)
 
 	def validate(self):
 		super(PurchaseOrder, self).validate()
@@ -258,9 +262,6 @@ class PurchaseOrder(BuyingController):
 		self.update_blanket_order()
 
 		unlink_inter_company_doc(self.doctype, self.name, self.inter_company_order_reference)
-
-	def on_update(self):
-		pass
 
 	def update_status_updater(self):
 		self.status_updater.append({

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -34,6 +34,7 @@ class SalesOrder(SellingController):
 
 	def validate(self):
 		super(SalesOrder, self).validate()
+		set_title()
 		self.validate_delivery_date()
 		self.validate_proj_cust()
 		self.validate_po()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -34,7 +34,6 @@ class SalesOrder(SellingController):
 
 	def validate(self):
 		super(SalesOrder, self).validate()
-		self.set_title()
 		self.validate_delivery_date()
 		self.validate_proj_cust()
 		self.validate_po()
@@ -305,6 +304,9 @@ class SalesOrder(SellingController):
 			update_bin_qty(item_code, warehouse, {
 				"reserved_qty": get_reserved_qty(item_code, warehouse)
 			})
+
+	def on_update(self):
+		pass
 
 	def set_title(self):
 		self.title = self.customer

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -34,7 +34,7 @@ class SalesOrder(SellingController):
 
 	def validate(self):
 		super(SalesOrder, self).validate()
-		set_title()
+		self.set_title()
 		self.validate_delivery_date()
 		self.validate_proj_cust()
 		self.validate_po()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -306,7 +306,9 @@ class SalesOrder(SellingController):
 			})
 
 	def on_update(self):
-		pass
+		self.title = self.customer
+		frappe.db.set_value("Sales Order",self.name,'title',self.customer)
+
 
 	def before_update_after_submit(self):
 		self.validate_po()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -34,6 +34,7 @@ class SalesOrder(SellingController):
 
 	def validate(self):
 		super(SalesOrder, self).validate()
+		self.set_title()
 		self.validate_delivery_date()
 		self.validate_proj_cust()
 		self.validate_po()
@@ -305,10 +306,8 @@ class SalesOrder(SellingController):
 				"reserved_qty": get_reserved_qty(item_code, warehouse)
 			})
 
-	def on_update(self):
+	def set_title(self):
 		self.title = self.customer
-		frappe.db.set_value("Sales Order",self.name,'title',self.customer)
-
 
 	def before_update_after_submit(self):
 		self.validate_po()


### PR DESCRIPTION
task: https://bloomstack.com/desk#Form/Task/TASK-2020-01956
-supplier/Customer title name same as Supplier/Customer name in Purchase Order/Sales Order form.
-supplier/Customer title name same as Supplier/Customer name in Purchase Invoice/Sales Invoice form.

purchase invoice
![purchase_invoice](https://user-images.githubusercontent.com/56826544/91016776-eab4cb80-e60a-11ea-917c-f184bd86ee42.gif)

purchase order
![purchase_order](https://user-images.githubusercontent.com/56826544/91016861-120b9880-e60b-11ea-9319-1c702d7d01f2.gif)

sales invoice
![sales_invoice](https://user-images.githubusercontent.com/56826544/91016926-2bace000-e60b-11ea-90f4-ba4eeceddc19.gif)

sales order
![sales_order](https://user-images.githubusercontent.com/56826544/91017006-4717eb00-e60b-11ea-84eb-859bb4e9f29e.gif)
