### PR TITLE
feat: For the Purchase invoice marked as paid

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -365,8 +365,12 @@ function hide_fields(doc) {
 	var parent_fields = ['due_date', 'is_opening', 'advances_section', 'from_date', 'to_date'];
 
 	if(cint(doc.is_paid) == 1) {
+		cur_frm.set_df_property('mode_of_payment', 'reqd', 1)
+		cur_frm.set_df_property('cash_bank_account', 'reqd', 1)
 		hide_field(parent_fields);
 	} else {
+		cur_frm.set_df_property('mode_of_payment', 'reqd', 0)
+		cur_frm.set_df_property('cash_bank_account', 'reqd', 0)
 		for (var i in parent_fields) {
 			var docfield = frappe.meta.docfield_map[doc.doctype][parent_fields[i]];
 			if(!docfield.hidden) unhide_field(parent_fields[i]);

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -308,6 +308,8 @@ erpnext.accounts.PurchaseInvoice = erpnext.buying.BuyingController.extend({
 	},
 
 	is_paid: function() {
+		this.frm.toggle_reqd('mode_of_payment', cint(this.frm.doc.is_paid) === 1);
+		this.frm.toggle_reqd('cash_bank_account', cint(this.frm.doc.is_paid) === 1);
 		hide_fields(this.frm.doc);
 		if(cint(this.frm.doc.is_paid)) {
 			this.frm.set_value("allocate_advances_automatically", 0);
@@ -365,12 +367,8 @@ function hide_fields(doc) {
 	var parent_fields = ['due_date', 'is_opening', 'advances_section', 'from_date', 'to_date'];
 
 	if(cint(doc.is_paid) == 1) {
-		cur_frm.set_df_property('mode_of_payment', 'reqd', 1)
-		cur_frm.set_df_property('cash_bank_account', 'reqd', 1)
 		hide_field(parent_fields);
 	} else {
-		cur_frm.set_df_property('mode_of_payment', 'reqd', 0)
-		cur_frm.set_df_property('cash_bank_account', 'reqd', 0)
 		for (var i in parent_fields) {
 			var docfield = frappe.meta.docfield_map[doc.doctype][parent_fields[i]];
 			if(!docfield.hidden) unhide_field(parent_fields[i]);


### PR DESCRIPTION
For the Purchase invoice marked as paid, make Payment section expanded, mode of payment and Cash/Bank Account highlighted.

task: https://bloomstack.com/desk#Form/Task/TASK-2020-01958

![is_paid purchase_invoice](https://user-images.githubusercontent.com/56826544/91128489-f5806680-e6c5-11ea-8fdd-a36b72c2d61e.gif)
