### PR TITLE
fix: client script added for tax row and tax breakup fix

### DIFF
--- a/erpnext/compliance/taxes.py
+++ b/erpnext/compliance/taxes.py
@@ -23,6 +23,8 @@ def calculate_cannabis_tax(doc):
 		# calculate cultivation tax for buying cycle
 		cultivation_taxes = calculate_cultivation_tax(doc)
 		for account, tax in cultivation_taxes.items():
+			if not tax:
+				continue
 			cultivation_tax_row = get_cultivation_tax_row(account, tax)
 			set_taxes(doc, cultivation_tax_row)
 	elif doc.doctype in ("Quotation", "Sales Order", "Sales Invoice", "Delivery Note"):
@@ -43,6 +45,8 @@ def calculate_cannabis_tax(doc):
 			# calculate cultivation tax for selling cycle if customer is a distributor
 			cultivation_taxes = calculate_cultivation_tax(doc)
 			for account, tax in cultivation_taxes.items():
+				if not tax:
+					continue
 				cultivation_tax_row = get_cultivation_tax_row(account, tax)
 				set_taxes(doc, cultivation_tax_row)
 		elif license_for == "Retailer":
@@ -197,6 +201,22 @@ def set_excise_tax(doc):
 
 	excise_tax_row = calculate_excise_tax(doc, compliance_items)
 	return excise_tax_row
+
+@frappe.whitelist()
+def set_cultivation_tax(doc):
+	if isinstance(doc, str):
+		doc = frappe._dict(json.loads(doc))
+
+	compliance_items = frappe.get_all('Compliance Item', fields=['item_code'])
+	if not compliance_items:
+		return
+
+	cultivation_taxes = calculate_cultivation_tax(doc)
+	for account, tax in cultivation_taxes.items():
+		if not tax:
+			continue
+		cultivation_tax_row = get_cultivation_tax_row(account, tax)
+		return cultivation_tax_row
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -631,7 +631,6 @@ def get_itemised_tax_breakup_html(doc):
 
 	# get tax breakup data
 	itemised_tax, itemised_taxable_amount = get_itemised_tax_breakup_data(doc)
-
 	get_rounded_tax_amount(itemised_tax, doc.precision("tax_amount", "taxes"))
 
 	update_itemised_tax_data(doc)

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -236,10 +236,12 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 	},
 
 	rate: function(doc, cdt, cdn) {
+		this._super(doc, cdt, cdn);
 		this.set_and_update_cultivation_tax();
 	},
 
 	items_remove: function(doc, cdt, cdn) {
+		this._super(doc, cdt, cdn);
 		this.set_and_update_cultivation_tax();
 	},
 

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -151,6 +151,7 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 					},
 					callback: (r) => {
 						this.frm.set_value("license", r.message);
+						this.set_and_update_cultivation_tax();
 
 						if (r.message) {
 							frappe.show_alert({
@@ -224,6 +225,22 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 		}
 
 		this._super(doc, cdt, cdn);
+		this.set_and_update_cultivation_tax();
+	},
+
+	item_code: function(doc, cdt, cdn) {
+		this._super(doc, cdt, cdn);
+		if (this.frm.doc.total) {
+			this.set_and_update_cultivation_tax();
+		}
+	},
+
+	rate: function(doc, cdt, cdn) {
+		this.set_and_update_cultivation_tax();
+	},
+
+	items_remove: function(doc, cdt, cdn) {
+		this.set_and_update_cultivation_tax();
 	},
 
 	received_qty: function(doc, cdt, cdn) {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -779,28 +779,27 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				callback: (r) => {
 					if (r.message) {
 						let taxes = me.frm.doc.taxes;
-						let excise_tax_row = r.message;
-						console.log("excise_tax_row", excise_tax_row);
-						if (excise_tax_row.tax_amount > 0) {
+						let cultivation_tax_row = r.message;
+						if (cultivation_tax_row.tax_amount > 0) {
 							if (taxes && taxes.length > 0) {
 								$.each(taxes, function (i, tax) {
-									if (tax.account_head == excise_tax_row.account_head) {
-										tax.tax_amount = excise_tax_row.tax_amount;
+									if (tax.account_head == cultivation_tax_row.account_head) {
+										tax.tax_amount = cultivation_tax_row.tax_amount;
 										me.frm.refresh_field('taxes');
 									} else {
-										me.frm.add_child('taxes', excise_tax_row);
+										me.frm.add_child('taxes', cultivation_tax_row);
 									}
 									me.calculate_taxes_and_totals();
 								});
 							} else {
-								me.frm.add_child('taxes', excise_tax_row);
+								me.frm.add_child('taxes', cultivation_tax_row);
 								me.frm.refresh_field('taxes');
 								me.calculate_taxes_and_totals();
 							}
-						} else if (excise_tax_row.tax_amount === 0) {
+						} else if (cultivation_tax_row.tax_amount === 0) {
 							if (taxes && taxes.length > 0) {
 								$.each(taxes, function (i, tax) {
-									if (tax.account_head == excise_tax_row.account_head) {
+									if (tax.account_head == cultivation_tax_row.account_head) {
 										me.frm.get_field("taxes").grid.grid_rows[i].remove();
 									}
 								});

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -756,16 +756,15 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		})
 	},
 	set_and_update_cultivation_tax: function () {
-		if (["Sales Order", "Sales Invoice", "Delivery Note", "Stock Entry"].includes(this.frm.doctype)) {
-			if (!this.frm.doc.license) {
+		const me = this;
+		if (["Quotation", "Sales Invoice", "Delivery Note", "Sales Order"].includes(me.frm.doctype)) {
+			if (!me.frm.doc.license) {
 				return;
 			}
 		}
 
-		const me = this;
-		frappe.db.get_value("Compliance Info", { "name": this.frm.doc.license }, "license_for", (r) => {
-			if (["Sales Order", "Sales Invoice", "Delivery Note", "Stock Entry"].includes(this.frm.doctype)) {
-				console.log("test");
+		frappe.db.get_value("Compliance Info", { "name": me.frm.doc.license }, "license_for", (r) => {
+			if (["Sales Order", "Sales Invoice", "Delivery Note", "Stock Entry"].includes(me.frm.doctype)) {
 				if (!r || r.license_for !== "Distributor") {
 					return;
 				}
@@ -774,7 +773,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 			frappe.call({
 				method: "erpnext.compliance.taxes.set_cultivation_tax",
 				args: {
-					doc: this.frm.doc
+					doc: me.frm.doc
 				},
 				callback: (r) => {
 					if (r.message) {

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -71,6 +71,7 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 				callback: (r) => {
 					me.frm.set_value("license", r.message);
 					me.set_and_update_excise_tax();
+					me.set_and_update_cultivation_tax();
 				}
 			});
 		};

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -136,6 +136,7 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 					callback: (r) => {
 						this.frm.set_value("license", r.message);
 						this.set_and_update_excise_tax();
+						this.set_and_update_cultivation_tax();
 
 						if (r.message) {
 							frappe.show_alert({
@@ -486,21 +487,25 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		}
 
 		this.set_and_update_excise_tax();
+		this.set_and_update_cultivation_tax();
 	},
 
 	item_code: function(doc, cdt, cdn) {
 		this._super(doc, cdt, cdn);
 		if (this.frm.doc.total) {
 			this.set_and_update_excise_tax();
+			this.set_and_update_cultivation_tax();
 		}
 	},
 
 	rate: function(doc, cdt, cdn) {
 		this.set_and_update_excise_tax();
+		this.set_and_update_cultivation_tax();
 	},
 
 	items_remove: function(doc, cdt, cdn) {
 		this.set_and_update_excise_tax();
+		this.set_and_update_cultivation_tax();
 	},
 
 	/* Determine appropriate batch number and set it in the form.


### PR DESCRIPTION
TASK ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01913
TASK ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01527

1. fixed show only cultivation tax row which has amount
2. fixed tax breakup
![Baldwin-Wells-PUR-ORD-2020-00060](https://user-images.githubusercontent.com/6947417/91162890-55890400-e6ea-11ea-8988-695caeee1e81.png)
