### PR TITLE
fix: jinja include spacing breaks authnet js inlining

### DIFF
--- a/erpnext/templates/pages/integrations/authorizenet_checkout.html
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.html
@@ -4,10 +4,7 @@
 
 {% block script %}
 <script>
-	{
-		%
-		include "templates/includes/integrations/authorizenet_checkout.js" %
-	}
+	{% include "templates/includes/integrations/authorizenet_checkout.js" %}
 </script>
 <script>
 	context = "{{ payment_context }}"


### PR DESCRIPTION
Authnet include jinja statement has an added new line between { and % breaking jinja. 