### PR TITLE
fix: validate pick list qty with Sales Order qty

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -117,6 +117,9 @@ class PickList(Document):
 		for row in self.locations:
 			if not row.picked_qty:
 				row.picked_qty = row.stock_qty
+			
+			if row.picked_qty > row.stock_qty:
+				frappe.throw(_("Row {0} : Picked Qty should be less or equal to Stock Qty").format(row.idx))
 
 	def update_order_package_tag(self, reset=False):
 		package_tags = [item.package_tag for item in self.locations if item.package_tag]

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -48,9 +48,10 @@ class PickList(Document):
 
 	def validate_stock_qty(self):
 		for row in self.locations:
-			order_qty = frappe.db.get_value("Sales Order Item", row.get("sales_order_item"), "qty")
-			if row.qty > order_qty:
-				frappe.throw(_("Row #{0}: Picked List item {1} Qty should be less than or equal to Order Qty {2}").format(frappe.bold(row.idx), frappe.bold(row.item_code), frappe.bold(order_qty)))
+			if row.get("sales_order_item"):
+				order_qty = frappe.db.get_value("Sales Order Item", row.get("sales_order_item"), "qty")
+				if row.qty > order_qty:
+					frappe.throw(_("Row #{0}: Picked List item {1} Qty should be less than or equal to Order Qty {2}").format(frappe.bold(row.idx), frappe.bold(row.item_code), frappe.bold(order_qty)))
 
 	def on_submit(self):
 		self.update_order_package_tag()
@@ -126,7 +127,7 @@ class PickList(Document):
 				row.picked_qty = row.stock_qty
 			
 			if row.picked_qty > row.stock_qty:
-				frappe.throw(_("Row #{0} : Picked Qty should be less or equal to Stock Qty").format(frappe.bold(row.idx), frappe.bold(row.stock_qty)))
+				frappe.throw(_("Row #{0} : Picked Qty should be less or equal to Stock Qty {1}").format(frappe.bold(row.idx), frappe.bold(row.stock_qty)))
 
 	def update_order_package_tag(self, reset=False):
 		package_tags = [item.package_tag for item in self.locations if item.package_tag]

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -33,7 +33,7 @@ class PickList(Document):
 				continue
 			if not item.serial_no:
 				frappe.throw(_("Row #{0}: {1} does not have any available serial numbers in {2}".format(
-					frappe.bold(item.idx), frappe.bold(item.item_code), frappe.bold(item.warehouse))))
+					item.idx, frappe.bold(item.item_code), frappe.bold(item.warehouse))))
 			if len(item.serial_no.split('\n')) == item.picked_qty:
 				continue
 			frappe.throw(_('For item {0} at row {1}, count of serial numbers does not match with the picked quantity')
@@ -47,11 +47,12 @@ class PickList(Document):
 		self.delivery_date = min(order_delivery_dates)
 
 	def validate_stock_qty(self):
-		for row in self.locations:
-			if row.get("sales_order_item"):
-				order_qty = frappe.db.get_value("Sales Order Item", row.get("sales_order_item"), "qty")
-				if row.qty > order_qty:
-					frappe.throw(_("Row #{0}: Picked List item {1} Qty should be less than or equal to Order Qty {2}").format(frappe.bold(row.idx), frappe.bold(row.item_code), frappe.bold(order_qty)))
+		for item in self.locations:
+			if item.get("sales_order_item"):
+				order_qty = frappe.db.get_value("Sales Order Item", item.get("sales_order_item"), "qty")
+				if item.qty > order_qty:
+					frappe.throw(_("Row #{0}: {1}'s quantity ({2}) should be less than or equal to the ordered quantity ({3})").format(
+						item.idx, frappe.bold(item.item_name), frappe.bold(item.qty), frappe.bold(order_qty)))
 
 	def on_submit(self):
 		self.update_order_package_tag()
@@ -125,9 +126,10 @@ class PickList(Document):
 		for row in self.locations:
 			if not row.picked_qty:
 				row.picked_qty = row.stock_qty
-			
+
 			if row.picked_qty > row.stock_qty:
-				frappe.throw(_("Row #{0} : Picked Qty should be less or equal to Stock Qty {1}").format(frappe.bold(row.idx), frappe.bold(row.stock_qty)))
+				frappe.throw(_("Row #{0}: Picked quantity ({1}) should be less or equal to the stock quantity ({2})").format(
+					row.idx, frappe.bold(row.picked_qty), frappe.bold(row.stock_qty)))
 
 	def update_order_package_tag(self, reset=False):
 		package_tags = [item.package_tag for item in self.locations if item.package_tag]


### PR DESCRIPTION
TASK ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01421

Pick list item qty should be less than or equal to sales order qty.

![Peek 2020-09-04 13-35](https://user-images.githubusercontent.com/6947417/92216136-8b30a880-eeb3-11ea-8ae2-5865d23529a5.gif)
