### PR TITLE
fix(Project): uncheck billable in projects

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -831,7 +831,6 @@ $(document).on('app_ready', function() {
 									})
 								},
 								() => {
-									frm.doc.billable = 0;
 									frm.save();
 								}
 							);

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -831,8 +831,8 @@ $(document).on('app_ready', function() {
 									})
 								},
 								() => {
-									frm.doc.billable = !frm.doc.billable;
-									refresh_field("billable");
+									frm.doc.billable = 0;
+									frm.save();
 								}
 							);
 						}


### PR DESCRIPTION
-    [Asana Task](https://app.asana.com/0/1188592895233593/1192060524520225)
-    `frm.doc.billable = !frm.doc.billable` when `billable` was unchecked, this condition again checked it, so removing this condition and saving the document does the trick.