### PR TITLE
feat: added a parent_task field in project_task_template

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -108,7 +108,6 @@ class Project(Document):
 					task_no.update({task.idx:task_doc.name})
 				# set parent_task to task
 				if task.parent_task:
-					task_id = task_no[task.idx]
 					doc = frappe.get_doc('Task',task_no[task.idx])
 					doc.parent_task = task_no[task.parent_task]
 					doc.save()

--- a/erpnext/projects/doctype/project_template/project_template.js
+++ b/erpnext/projects/doctype/project_template/project_template.js
@@ -6,3 +6,12 @@ frappe.ui.form.on('Project Template', {
 
 	// }
 });
+frappe.ui.form.on('Project Template Task', {
+	parent_task:function(frm,cdt,cdn){
+		var row = locals[cdt][cdn];
+		if(row.parent_task != null && (row.parent_task <= 0 || row.parent_task > frm.doc.tasks.length || row.parent_task === row.idx)){
+			frappe.msgprint(__('Invalid Parent Task value'));
+			frappe.model.set_value(cdt,cdn,"parent_task",null);
+		}
+	}
+});

--- a/erpnext/projects/doctype/project_template_task/project_template_task.json
+++ b/erpnext/projects/doctype/project_template_task/project_template_task.json
@@ -7,8 +7,11 @@
   "subject",
   "start",
   "duration",
+  "column_break_4",
   "task_weight",
   "assigned_user",
+  "parent_task",
+  "section_break_8",
   "description"
  ],
  "fields": [
@@ -49,10 +52,23 @@
    "fieldtype": "Link",
    "label": "Assigned User",
    "options": "User"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "parent_task",
+   "fieldtype": "Int",
+   "label": "Parent Task"
+  },
+  {
+   "fieldname": "section_break_8",
+   "fieldtype": "Section Break"
   }
  ],
  "istable": 1,
- "modified": "2020-09-01 00:55:10.893286",
+ "modified": "2020-09-15 23:27:25.375270",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Template Task",


### PR DESCRIPTION
Project Template Task
Add an Int field called Parent Task (this will reference other task rows in this child table)
Add a validation for this field: it shouldn't be greater than the number of rows in the child table

Project
When a Project is created with Tasks using a Project Template (that has the above field set), for every task, find the respective parent task and set it.
Create the parent tasks first, and then create the child tasks

![project_template](https://user-images.githubusercontent.com/56826544/93304257-61b03f00-f81a-11ea-87bd-44024da33d6d.gif)
