### PR TITLE
fix: Split plant batch into new batch

### DIFF
--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.js
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.js
@@ -82,19 +82,16 @@ frappe.ui.form.on('Plant Batch', {
 	split_plant_batch: function(frm) {
 		frappe.prompt([{
 			fieldname: 'split_count',
-			label: __('New Batch Qty'),
+			label: __('New Plant Batch Untracked Count'),
 			fieldtype: 'Int',
 		},
 		{
-			fieldname: 'new_batch_id',
-			label: __('New Batch ID (Optional)'),
+			fieldname: 'new_plant_batch_id',
+			label: __('New Plant Batch ID'),
 			fieldtype: 'Data',
+			reqd: 1
 		}],
 		(data) => {
-			if (frm.doc.untracked_count < data.split_count) {
-				frappe.throw(__("The Split count ({0}) should be less or equal than the untracked quantity ({1})",
-					[data.split_count, frm.doc.untracked_count]));
-			}
 			frappe.call({
 				method: 'erpnext.agriculture.doctype.plant_batch.plant_batch.split_plant_batch',
 				args: {
@@ -103,11 +100,12 @@ frappe.ui.form.on('Plant Batch', {
 					start_date: frm.doc.start_date,
 					location: frm.doc.location,
 					split_count: data.split_count,
-					new_batch_id: data.new_batch_id,
+					new_plant_batch_id: data.new_plant_batch_id,
 					reference_name: frm.doc.name
 				},
 				callback: (r) => {
 					frm.refresh();
+					frappe.set_route('Form', "Plant Batch", r.message);
 				},
 			});
 		},

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.js
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.js
@@ -40,14 +40,13 @@ frappe.ui.form.on('Plant Batch', {
 			});
 		});
 
-		frm.set_df_property("untracked_count", "read_only", frm.is_new() ? 0 : 1);
-
+		frm.toggle_enable("untracked_count", frm.is_new())
+		// frm.set_df_property("untracked_count", "read_only", frm.is_new() ? 0 : 1);
 		if (!frm.is_new()) {
-			frm.add_custom_button(__("Split Plant Batch"), () => {
+			frm.add_custom_button(__("Plant Batch"), () => {
 				frm.trigger("split_plant_batch");
 			}, __("Create"));
 		}
-
 	},
 
 	destroy_plant_batch: (frm) => {

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.js
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.js
@@ -90,9 +90,6 @@ frappe.ui.form.on('Plant Batch', {
 			reqd: 1
 		}],
 		(data) => {
-			if (frm.doc.untracked_count < data.split_count) {
-				frappe.throw(__("The Split count ({0}) should be less than or equal to the untracked quantity ({1})", [data.split_count.bold(), frm.doc.untracked_count.bold()]));
-			}
 			frm.call('split_plant_batch', {
 				split_count: data.split_count,
 				new_plant_batch_id: data.new_plant_batch_id,

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.js
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.js
@@ -39,8 +39,7 @@ frappe.ui.form.on('Plant Batch', {
 				obj_to_append: obj_to_append
 			});
 		});
-
-		frm.toggle_enable("untracked_count", frm.is_new())
+		frm.toggle_enable("untracked_count", frm.is_new());
 		if (!frm.is_new()) {
 			frm.add_custom_button(__("Plant Batch"), () => {
 				frm.trigger("split_plant_batch");

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.json
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.json
@@ -254,7 +254,7 @@
    "options": "Plant Tag"
   }
  ],
- "modified": "2020-09-15 22:57:54.641618",
+ "modified": "2020-09-16 03:35:21.336302",
  "modified_by": "Administrator",
  "module": "Agriculture",
  "name": "Plant Batch",

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.json
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.json
@@ -208,12 +208,14 @@
   {
    "fieldname": "tracked_count",
    "fieldtype": "Int",
-   "label": "Tracked Count"
+   "label": "Tracked Count",
+   "read_only": 1
   },
   {
    "fieldname": "packaged_count",
    "fieldtype": "Int",
-   "label": "Packaged Count"
+   "label": "Packaged Count",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_37",
@@ -222,12 +224,14 @@
   {
    "fieldname": "harvested_count",
    "fieldtype": "Int",
-   "label": "Harvested Count"
+   "label": "Harvested Count",
+   "read_only": 1
   },
   {
    "fieldname": "destroyed_count",
    "fieldtype": "Int",
-   "label": "Destroyed Count"
+   "label": "Destroyed Count",
+   "read_only": 1
   },
   {
    "description": "The minimum distance between each plant for optimum growth",
@@ -250,7 +254,7 @@
    "options": "Plant Tag"
   }
  ],
- "modified": "2020-08-25 07:20:07.654098",
+ "modified": "2020-09-15 22:57:54.641618",
  "modified_by": "Administrator",
  "module": "Agriculture",
  "name": "Plant Batch",

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -74,6 +74,29 @@ class PlantBatch(Document):
 		).insert()
 		destroyed_plant_log.submit()
 		return destroyed_plant_log.name
+	def split_plant_batch(self, split_count, new_plant_batch_id):
+
+		if self.untracked_count == 0:
+			frappe.throw(_("Cannot Split Plant Batch as there is no untracked count."))
+
+		if self.untracked_count < int(split_count):
+			frappe.throw(_("The Split count ({0}) should be less or equal to the untracked quantity ({1})").format(split_count, self.untracked_count))
+
+		plant_batch = frappe.get_doc(
+			dict(
+				doctype='Plant Batch',
+				title=new_plant_batch_id,
+				strain = self.strain,
+				start_date = getdate(nowdate()),
+				untracked_count = split_count,
+				location = self.location
+			)
+		).insert()
+		self.untracked_count -= int(split_count)
+		self.save()
+
+		return plant_batch.name
+
 
 def get_coordinates(doc):
 	return ast.literal_eval(doc.location).get('features')[0].get('geometry').get('coordinates')

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -161,25 +161,3 @@ def make_harvest(source_name, target_doc=None):
 		}}, target_doc, update_plant)
 
 	return target_doc
-
-@frappe.whitelist()
-def split_plant_batch(strain, start_date, location, split_count, new_plant_batch_id=None, reference_name=None):
-	"""Split the plant batch into a new plant batch."""
-	prev_plant_batch = frappe.get_doc('Plant Batch', reference_name)
-
-	if prev_plant_batch.untracked_count < int(split_count):
-		frappe.throw(_("The Split count ({0}) should be less or equal to the untracked quantity ({1})").format(split_count, prev_plant_batch.untracked_count))
-
-	plant_batch = frappe.get_doc(
-		dict(doctype='Plant Batch', 
-			title=new_plant_batch_id,
-			strain = strain,
-			start_date = start_date,
-			untracked_count = split_count,
-			location = location)
-			).insert()
-
-	prev_plant_batch.untracked_count = prev_plant_batch.untracked_count - int(split_count)
-	prev_plant_batch.save()
-
-	return plant_batch.name

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -30,7 +30,7 @@ class PlantBatch(Document):
 		if strain.cultivation_task:
 			self.project = create_project(self.title, self.start_date, strain.period)
 			create_tasks(strain.cultivation_task, self.project, self.start_date)
-	
+
 	def reload_linked_analysis(self):
 		linked_doctypes = ['Soil Texture', 'Soil Analysis', 'Plant Analysis']
 		required_fields = ['location', 'name', 'collection_datetime']

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -74,6 +74,7 @@ class PlantBatch(Document):
 		).insert()
 		destroyed_plant_log.submit()
 		return destroyed_plant_log.name
+
 	def split_plant_batch(self, split_count, new_plant_batch_id):
 		if self.untracked_count == 0:
 			frappe.throw(_("Cannot split Plant Batch as there is no untracked count."))

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -75,21 +75,20 @@ class PlantBatch(Document):
 		destroyed_plant_log.submit()
 		return destroyed_plant_log.name
 	def split_plant_batch(self, split_count, new_plant_batch_id):
-
 		if self.untracked_count == 0:
-			frappe.throw(_("Cannot Split Plant Batch as there is no untracked count."))
+			frappe.throw(_("Cannot split Plant Batch as there is no untracked count."))
 
 		if self.untracked_count < int(split_count):
-			frappe.throw(_("The Split count ({0}) should be less or equal to the untracked quantity ({1})").format(split_count, self.untracked_count))
+			frappe.throw(_("The split count ({0}) should be less or equal to the untracked quantity ({1})").format(split_count, self.untracked_count))
 
 		plant_batch = frappe.get_doc(
 			dict(
 				doctype='Plant Batch',
 				title=new_plant_batch_id,
-				strain = self.strain,
-				start_date = getdate(nowdate()),
-				untracked_count = split_count,
-				location = self.location
+				strain=self.strain,
+				start_date=getdate(nowdate()),
+				untracked_count=split_count,
+				location=self.location
 			)
 		).insert()
 		self.untracked_count -= int(split_count)

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -30,7 +30,7 @@ class PlantBatch(Document):
 		if strain.cultivation_task:
 			self.project = create_project(self.title, self.start_date, strain.period)
 			create_tasks(strain.cultivation_task, self.project, self.start_date)
-
+	
 	def reload_linked_analysis(self):
 		linked_doctypes = ['Soil Texture', 'Soil Analysis', 'Plant Analysis']
 		required_fields = ['location', 'name', 'collection_datetime']
@@ -138,3 +138,25 @@ def make_harvest(source_name, target_doc=None):
 		}}, target_doc, update_plant)
 
 	return target_doc
+
+@frappe.whitelist()
+def split_plant_batch(strain, start_date, location, split_count, new_batch_id=None, reference_name=None):
+	"""Split the plant batch into a new plant batch"""
+	prev_plant_batch = frappe.get_doc('Plant Batch', reference_name)
+
+	if prev_plant_batch.untracked_count < int(split_count):
+		frappe.throw(_("The Split count ({0}) should be less or equal to the untracked quantity ({1})").format(split_count, prev_plant_batch.untracked_count))
+
+	plant_batch = frappe.get_doc(
+		dict(doctype='Plant Batch', 
+			title=new_batch_id,
+			strain = strain,
+			start_date = start_date,
+			untracked_count = split_count,
+			location = location)
+			).insert()
+
+	prev_plant_batch.untracked_count = prev_plant_batch.untracked_count - int(split_count)
+	prev_plant_batch.save()
+
+	return plant_batch.name

--- a/erpnext/agriculture/doctype/plant_batch/plant_batch.py
+++ b/erpnext/agriculture/doctype/plant_batch/plant_batch.py
@@ -140,8 +140,8 @@ def make_harvest(source_name, target_doc=None):
 	return target_doc
 
 @frappe.whitelist()
-def split_plant_batch(strain, start_date, location, split_count, new_batch_id=None, reference_name=None):
-	"""Split the plant batch into a new plant batch"""
+def split_plant_batch(strain, start_date, location, split_count, new_plant_batch_id=None, reference_name=None):
+	"""Split the plant batch into a new plant batch."""
 	prev_plant_batch = frappe.get_doc('Plant Batch', reference_name)
 
 	if prev_plant_batch.untracked_count < int(split_count):
@@ -149,7 +149,7 @@ def split_plant_batch(strain, start_date, location, split_count, new_batch_id=No
 
 	plant_batch = frappe.get_doc(
 		dict(doctype='Plant Batch', 
-			title=new_batch_id,
+			title=new_plant_batch_id,
 			strain = strain,
 			start_date = start_date,
 			untracked_count = split_count,


### PR DESCRIPTION
TASK ID: [Asana](https://app.asana.com/0/1191634438432931/1188461304622541)

- [x] Make un-track field read only after save
- [x] make field read only of statistic section
- [x] Split current plant batch into new plant batch
- [x] update untracked count from previous plant batch

![Peek 2020-09-16 15-46](https://user-images.githubusercontent.com/6947417/93324790-fa06ed80-f833-11ea-8030-8ba7f8ad4c47.gif)