### PR TITLE
fix: text overlap on authorizenet page

### DIFF
--- a/erpnext/templates/pages/integrations/authorizenet_checkout.css
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.css
@@ -7,7 +7,7 @@
 }
 
 .authorizenet h2 {
-    margin-top: 30px;
+    margin-top: 50px;
 }
 
 .authorizenet .submit_row .row {


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1188891334286761/1194343904652639/f

**Screenshot:**
![screenshot-localhost_8001-2020 09 17-17_42_44](https://user-images.githubusercontent.com/45919049/93468845-3c502d80-f90d-11ea-97e7-ffe0ccdf4ae1.png)
