### PR TITLE
fix(report): removed opening and closing from statement of account report

### DIFF
--- a/erpnext/accounts/report/statement_of_account/statement_of_account.html
+++ b/erpnext/accounts/report/statement_of_account/statement_of_account.html
@@ -38,23 +38,14 @@
 				<td>{%= frappe.datetime.str_to_user(data[i].posting_date) %}</td>
 				<td>{%= data[i].voucher_type %}
 					<br>{%= data[i].voucher_no %}</td>
-					<td style="text-align: right">
-						{%= format_currency(data[i].debit, filters.presentation_currency) %}</td>
-					<td style="text-align: right">
+				<td style="text-align: right">
+					{%= format_currency(data[i].debit, filters.presentation_currency) %}</td>
+				<td style="text-align: right">
 						{%= format_currency(data[i].credit, filters.presentation_currency) %}</td>
-			{% } else { %}
-				<td></td>
-				<td><b>{%= frappe.format(data[i].account, {fieldtype: "Link"}) || "&nbsp;" %}</b></td>
-				<td style="text-align: right">
-					{%= data[i].account && format_currency(data[i].debit, filters.presentation_currency) %}
-				</td>
-				<td style="text-align: right">
-					{%= data[i].account && format_currency(data[i].credit, filters.presentation_currency) %}
-				</td>
-			{% } %}
 				<td style="text-align: right">
 					{%= format_currency(data[i].balance, filters.presentation_currency) %}
 				</td>
+			{% } %}
 			</tr>
 		{% } %}
 	</tbody>

--- a/erpnext/accounts/report/statement_of_account/statement_of_account.py
+++ b/erpnext/accounts/report/statement_of_account/statement_of_account.py
@@ -132,15 +132,11 @@ def get_data_with_opening_closing(filters, account_details, gl_entries):
 
 	totals, entries = get_accountwise_gle(filters, gl_entries, gle_map)
 
-	# Opening for filtered account
-	data.append(totals.opening)
 	data += entries
 
 	# totals
 	data.append(totals.total)
 
-	# closing
-	data.append(totals.closing)
 	return data
 
 def initialize_gle_map(gl_entries, filters):


### PR DESCRIPTION
TASK ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01172

Problem Statement: Remove opening and closing row from statement of account report.

solution:
![Statement-of-Account (3)](https://user-images.githubusercontent.com/6947417/94025909-acabf280-fdd6-11ea-9d24-85e5f796c2c3.png)
![Desktop-screenshot (2)](https://user-images.githubusercontent.com/6947417/94025915-ae75b600-fdd6-11ea-97ca-2a837888821e.png)
