### PR TITLE
feat: set Purchase Receipt status based on qty instead of amount

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -87,6 +87,13 @@ class PurchaseInvoice(BuyingController):
 		if self._action=="submit" and self.update_stock:
 			self.make_batches('warehouse')
 
+		check_overbilling_against = frappe.db.get_single_value("Buying Settings", "check_overbilling_against")
+		overbilling_based_on = "amount"
+		if check_overbilling_against == "Quantity":
+			overbilling_based_on = "qty"
+		elif check_overbilling_against == "Amount":
+			overbilling_based_on = "amount"
+
 		self.validate_release_date()
 		self.check_conversion_rate()
 		self.validate_credit_to_acc()
@@ -98,7 +105,7 @@ class PurchaseInvoice(BuyingController):
 		self.set_expense_account(for_validate=True)
 		self.set_against_expense_account()
 		self.validate_write_off_account()
-		self.validate_multiple_billing("Purchase Receipt", "pr_detail", "amount", "items")
+		self.validate_multiple_billing("Purchase Receipt", "pr_detail", overbilling_based_on, "items")
 		self.create_remarks()
 		self.set_status()
 		self.validate_purchase_receipt_if_update_stock()

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -12,7 +12,7 @@ from erpnext.assets.doctype.asset_category.asset_category import get_asset_categ
 from erpnext.controllers.buying_controller import BuyingController
 from erpnext.accounts.party import get_party_account, get_due_date
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
-from erpnext.stock.doctype.purchase_receipt.purchase_receipt import update_billed_amount_based_on_po
+from erpnext.stock.doctype.purchase_receipt.purchase_receipt import update_billed_amount_based_on_po, update_billed_qty_based_on_po
 from erpnext.stock import get_warehouse_account_map
 from erpnext.accounts.general_ledger import make_gl_entries, merge_similar_entries, delete_gl_entries
 from erpnext.accounts.doctype.gl_entry.gl_entry import update_outstanding_amt
@@ -932,19 +932,28 @@ class PurchaseInvoice(BuyingController):
 					frappe.throw(_("Supplier Invoice No exists in Purchase Invoice {0}".format(pi)))
 
 	def update_billing_status_in_pr(self, update_modified=True):
-		updated_pr = []
-		for d in self.get("items"):
-			if d.pr_detail:
-				billed_amt = frappe.db.sql("""select sum(amount) from `tabPurchase Invoice Item`
-					where pr_detail=%s and docstatus=1""", d.pr_detail)
-				billed_amt = billed_amt and billed_amt[0][0] or 0
-				frappe.db.set_value("Purchase Receipt Item", d.pr_detail, "billed_amt", billed_amt, update_modified=update_modified)
-				updated_pr.append(d.purchase_receipt)
-			elif d.po_detail:
-				updated_pr += update_billed_amount_based_on_po(d.po_detail, update_modified)
+		updated_receipts = []
+		for item in self.get("items"):
+			if item.pr_detail:
+				billed_values = frappe.get_all("Purchase Invoice Item",
+					filters={"docstatus": 1, "pr_detail": item.pr_detail},
+					fields=["sum(amount) as amount", "sum(qty) as qty"])
+				billed_amt = billed_values and flt(billed_values[0].amount)
+				billed_qty = billed_values and flt(billed_values[0].qty)
 
-		for pr in set(updated_pr):
-			frappe.get_doc("Purchase Receipt", pr).update_billing_percentage(update_modified=update_modified)
+				frappe.db.set_value("Purchase Receipt Item", item.pr_detail, "billed_amt", billed_amt, update_modified=update_modified)
+				frappe.db.set_value("Purchase Receipt Item", item.pr_detail, "billed_qty", billed_qty, update_modified=update_modified)
+				updated_receipts.append(item.purchase_receipt)
+			elif item.po_detail:
+				updated_receipts += update_billed_amount_based_on_po(item.po_detail, update_modified)
+				updated_receipts += update_billed_qty_based_on_po(item.po_detail, update_modified)
+
+		for pr in set(updated_receipts):
+			frappe.get_doc("Purchase Receipt", pr).update_billing_percentage(
+				target_ref_field="qty",
+				target_field="billed_qty",
+				update_modified=update_modified
+			)
 
 	def on_recurring(self, reference_doc, auto_repeat_doc):
 		self.due_date = None
@@ -984,7 +993,7 @@ class PurchaseInvoice(BuyingController):
 
 		# calculate totals again after applying TDS
 		self.calculate_taxes_and_totals()
-	
+
 	def set_status(self, update=False, status=None, update_modified=True):
 		if self.is_new():
 			if self.get('amended_from'):

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -91,8 +91,6 @@ class PurchaseInvoice(BuyingController):
 		overbilling_based_on = "amount"
 		if check_overbilling_against == "Quantity":
 			overbilling_based_on = "qty"
-		elif check_overbilling_against == "Amount":
-			overbilling_based_on = "amount"
 
 		self.validate_release_date()
 		self.check_conversion_rate()

--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -3,10 +3,12 @@
  "description": "Settings for Buying Module",
  "doctype": "DocType",
  "document_type": "Other",
+ "engine": "InnoDB",
  "field_order": [
   "supp_master_name",
   "supplier_group",
   "buying_price_list",
+  "check_overbilling_against",
   "column_break_3",
   "po_required",
   "pr_required",
@@ -94,12 +96,19 @@
    "fieldname": "disable_cultivation_tax_for_purchase_receipt",
    "fieldtype": "Check",
    "label": "Disable cultivation tax for Purchase Receipt"
+  },
+  {
+   "default": "Amount",
+   "fieldname": "check_overbilling_against",
+   "fieldtype": "Select",
+   "label": "Check Overbilling Against",
+   "options": "Amount\nQuantity"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
- "modified": "2020-09-21 22:15:32.017216",
+ "modified": "2020-09-24 04:43:52.270309",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",
@@ -114,5 +123,7 @@
    "share": 1,
    "write": 1
   }
- ]
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
 }

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -620,7 +620,7 @@ class AccountsController(TransactionBase):
 
 			if not ref_val:
 				frappe.msgprint(_("Warning: System will not check overbilling since {0} for Item {1} in {2} is zero").format(
-					based_on, item.item_code, ref_dt))
+					frappe.bold(based_on), frappe.bold(item.item_code), frappe.bold(ref_dt)))
 				return
 
 			already_billed = frappe.get_all(self.doctype + " Item",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -610,41 +610,45 @@ class AccountsController(TransactionBase):
 
 	def validate_multiple_billing(self, ref_dt, item_ref_dn, based_on, parentfield):
 		from erpnext.controllers.status_updater import get_allowance_for
-		item_allowance = {}
-		global_qty_allowance, global_amount_allowance = None, None
 
-		for item in self.get("items"):
-			if item.get(item_ref_dn):
-				ref_amt = flt(frappe.db.get_value(ref_dt + " Item",
-					item.get(item_ref_dn), based_on), self.precision(based_on, item))
-				if not ref_amt:
-					frappe.msgprint(
-						_("Warning: System will not check overbilling since amount for Item {0} in {1} is zero")
-							.format(item.item_code, ref_dt))
-				else:
-					already_billed = frappe.db.sql("""
-						select sum(%s)
-						from `tab%s`
-						where %s=%s and docstatus=1 and parent != %s
-					""" % (based_on, self.doctype + " Item", item_ref_dn, '%s', '%s'),
-					   (item.get(item_ref_dn), self.name))[0][0]
+		for item in self.get(parentfield):
+			if not item.get(item_ref_dn):
+				return
 
-					total_billed_amt = flt(flt(already_billed) + flt(item.get(based_on)),
-						self.precision(based_on, item))
+			ref_dt_item = ref_dt + " Item"
+			ref_val = flt(frappe.db.get_value(ref_dt_item, item.get(item_ref_dn), based_on), self.precision(based_on, item))
 
-					allowance, item_allowance, global_qty_allowance, global_amount_allowance = \
-						get_allowance_for(item.item_code, item_allowance, global_qty_allowance, global_amount_allowance, "amount")
+			if not ref_val:
+				frappe.msgprint(_("Warning: System will not check overbilling since {0} for Item {1} in {2} is zero").format(
+					based_on, item.item_code, ref_dt))
+				return
 
-					max_allowed_amt = flt(ref_amt * (100 + allowance) / 100)
+			already_billed = frappe.get_all(self.doctype + " Item",
+				filters={
+					"docstatus": 1,
+					"parent": ["!=", self.name],
+					item_ref_dn: item.get(item_ref_dn)
+				},
+				fields=["sum({}) as billed_val".format(based_on)])
 
-					if total_billed_amt < 0 and max_allowed_amt < 0:
-						# while making debit note against purchase return entry(purchase receipt) getting overbill error
-						total_billed_amt = abs(total_billed_amt)
-						max_allowed_amt = abs(max_allowed_amt)
+			already_billed = already_billed and already_billed[0].billed_val
+			total_billed_val = flt(flt(already_billed) + flt(item.get(based_on)), self.precision(based_on, item))
 
-					if total_billed_amt - max_allowed_amt > 0.01:
-						frappe.throw(_("Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings")
-							.format(item.item_code, item.idx, max_allowed_amt))
+			allowance, *other_allowances = get_allowance_for(item_code=item.item_code, qty_or_amount=based_on)
+
+			max_allowed_val = flt(ref_val * (100 + allowance) / 100)
+			if total_billed_val < 0 and max_allowed_val < 0:
+				# while making debit note against purchase return entry(purchase receipt) getting overbill error
+				total_billed_val = abs(total_billed_val)
+				max_allowed_val = abs(max_allowed_val)
+
+			if total_billed_val - max_allowed_val > 0.01:
+				settings_doc = "Stock Settings" if based_on == "qty" else "Accounts Settings"
+				settings_doc = get_link_to_form(settings_doc, settings_doc)
+
+				frappe.throw(_("""Row {0}: Cannot overbill item {1} for more than {2}.
+					To allow over-billing, please set an allowance in {3}.""").format(
+						item.idx, frappe.bold(item.item_code), frappe.bold(max_allowed_val), settings_doc))
 
 	def get_company_default(self, fieldname):
 		from erpnext.accounts.utils import get_company_default

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -373,10 +373,14 @@ class StatusUpdater(Document):
 			ref_doc.db_set("per_billed", per_billed)
 			ref_doc.set_status(update=True)
 
-def get_allowance_for(item_code, item_allowance={}, global_qty_allowance=None, global_amount_allowance=None, qty_or_amount="qty"):
+def get_allowance_for(item_code, item_allowance=None, global_qty_allowance=None, global_amount_allowance=None, qty_or_amount="qty"):
 	"""
 		Returns the allowance for the item, if not set, returns global allowance
 	"""
+
+	if not item_allowance:
+		item_allowance = {}
+
 	if qty_or_amount == "qty":
 		if item_allowance.get(item_code, frappe._dict()).get("qty"):
 			return item_allowance[item_code].qty, item_allowance, global_qty_allowance, global_amount_allowance

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -324,13 +324,13 @@ class StockController(AccountsController):
 		for w in warehouses:
 			validate_warehouse_company(w, self.company)
 
-	def update_billing_percentage(self, update_modified=True):
+	def update_billing_percentage(self, target_ref_field="amount", target_field="billed_amt", update_modified=True):
 		self._update_percent_field({
 			"target_dt": self.doctype + " Item",
 			"target_parent_dt": self.doctype,
 			"target_parent_field": "per_billed",
-			"target_ref_field": "amount",
-			"target_field": "billed_amt",
+			"target_ref_field": target_ref_field,
+			"target_field": target_field,
 			"name": self.name,
 		}, update_modified)
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -694,3 +694,4 @@ erpnext.patches.v13_0.update_delivery_note_status
 erpnext.patches.v13_0.delete_old_agri_doctypes
 erpnext.patches.v13_0.set_auto_create_invoice_on_delivery_note
 erpnext.patches.v13_0.update_item_master_doctype_field
+erpnext.patches.v13_0.update_billed_qty_in_purchase_receipt

--- a/erpnext/patches/v13_0/update_billed_qty_in_purchase_receipt.py
+++ b/erpnext/patches/v13_0/update_billed_qty_in_purchase_receipt.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc("buying", "doctype", "buying_settings")
+	frappe.reload_doc("stock", "doctype", "purchase_receipt_item")
+	frappe.reload_doc("stock", "doctype", "purchase_receipt")
+
+	buying_settings = frappe.get_single("Buying Settings")
+	buying_settings.check_overbilling_against = "Amount"
+	buying_settings.save()
+
+	purchase_invoices = frappe.get_all("Purchase Invoice", filters={"docstatus": 1})
+	for invoice in purchase_invoices:
+		invoice_doc = frappe.get_doc("Purchase Invoice", invoice.name)
+		invoice_doc.update_billing_status_in_pr(update_modified=False)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -541,18 +541,15 @@ def update_billed_amount_based_on_po(po_detail, update_modified=True):
 
 
 def update_billed_qty_based_on_po(po_detail, update_modified=True):
-	po_billed_qty = frappe.db.sql("""
-		SELECT
-			SUM(qty)
-		FROM
-			`tabPurchase Invoice Item`
-		WHERE
-			po_detail = %s
-				AND (pr_detail IS NULL OR pr_detail = '')
-				AND docstatus = 1
-	""", po_detail)
+	po_billed_qty = frappe.get_all("Purchase Invoice Item",
+		filters={"docstatus": 1, "po_detail": po_detail},
+		or_filters=[
+			{"pr_detail": ""},
+			{"pr_detail": None}
+		],
+		fields=["sum(qty) as qty"])
 
-	po_billed_qty = po_billed_qty and po_billed_qty[0][0] or 0
+	po_billed_qty = po_billed_qty and po_billed_qty[0].qty or 0
 
 	# Get all Delivery Note Item rows against the Purchase Order Item row
 	pr_details = frappe.db.sql("""

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -444,14 +444,19 @@ class PurchaseReceipt(BuyingController):
 		clear_doctype_notifications(self)
 
 	def update_billing_status(self, update_modified=True):
-		updated_pr = [self.name]
-		for d in self.get("items"):
-			if d.purchase_order_item:
-				updated_pr += update_billed_amount_based_on_po(d.purchase_order_item, update_modified)
+		updated_receipts = [self.name]
+		for item in self.get("items"):
+			if item.purchase_order_item:
+				updated_receipts += update_billed_amount_based_on_po(item.purchase_order_item, update_modified)
+				updated_receipts += update_billed_qty_based_on_po(item.purchase_order_item, update_modified)
 
-		for pr in set(updated_pr):
+		for pr in set(updated_receipts):
 			pr_doc = self if (pr == self.name) else frappe.get_doc("Purchase Receipt", pr)
-			pr_doc.update_billing_percentage(update_modified=update_modified)
+			pr_doc.update_billing_percentage(
+				target_ref_field="qty",
+				target_field="billed_qty",
+				update_modified=update_modified
+			)
 
 		self.load_from_db()
 
@@ -533,6 +538,65 @@ def update_billed_amount_based_on_po(po_detail, update_modified=True):
 		updated_pr.append(pr_item.parent)
 
 	return updated_pr
+
+
+def update_billed_qty_based_on_po(po_detail, update_modified=True):
+	po_billed_qty = frappe.db.sql("""
+		SELECT
+			SUM(qty)
+		FROM
+			`tabPurchase Invoice Item`
+		WHERE
+			po_detail = %s
+				AND (pr_detail IS NULL OR pr_detail = '')
+				AND docstatus = 1
+	""", po_detail)
+
+	po_billed_qty = po_billed_qty and po_billed_qty[0][0] or 0
+
+	# Get all Delivery Note Item rows against the Purchase Order Item row
+	pr_details = frappe.db.sql("""
+		SELECT
+			pr_item.name,
+			pr_item.qty,
+			pr_item.parent
+		FROM
+			`tabPurchase Receipt Item` pr_item,
+			`tabPurchase Receipt` pr
+		WHERE
+			pr.name = pr_item.parent
+				AND pr_item.purchase_order_item = %s
+				AND pr.docstatus = 1
+				AND pr.is_return = 0
+		ORDER BY
+			pr.posting_date asc,
+			pr.posting_time asc,
+			pr.name asc
+	""", po_detail, as_dict=1)
+
+	updated_receipts = []
+	for pr_item in pr_details:
+		# Get billed qty directly against Purchase Receipt
+		pr_billed_qty = frappe.get_all("Purchase Invoice Item",
+			filters={"docstatus": 1, "pr_detail": pr_item.name},
+			fields=["sum(qty) as qty"])
+		pr_billed_qty = pr_billed_qty and pr_billed_qty[0].qty or 0
+
+		# Distribute billed qty directly against PO between PRs based on FIFO
+		if po_billed_qty and pr_billed_qty < pr_item.qty:
+			pending_qty_to_bill = flt(pr_item.qty) - pr_billed_qty
+			if pending_qty_to_bill <= po_billed_qty:
+				pr_billed_qty += pending_qty_to_bill
+				po_billed_qty -= pending_qty_to_bill
+			else:
+				pr_billed_qty += po_billed_qty
+				po_billed_qty = 0
+
+		frappe.db.set_value("Purchase Receipt Item", pr_item.name, "billed_qty", pr_billed_qty, update_modified=update_modified)
+		updated_receipts.append(pr_item.parent)
+
+	return updated_receipts
+
 
 @frappe.whitelist()
 def make_purchase_invoice(source_name, target_doc=None):

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -29,6 +29,7 @@
   "received_qty",
   "qty",
   "rejected_qty",
+  "billed_qty",
   "col_break2",
   "uom",
   "stock_uom",
@@ -832,11 +833,17 @@
    "fieldtype": "Link",
    "label": "Package Tag",
    "options": "Package Tag"
+  },
+  {
+   "fieldname": "billed_qty",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Billed Qty"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-09-22 00:26:04.953070",
+ "modified": "2020-09-24 03:24:24.085801",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
**Changes:**

- [x] On submit of a Purchase Invoice, the billing status of any linked Purchase Receipts will be based on the received item quantity, rather than the amount.
- [x] Change overbilling message trigger for quantity instead of amount
- [x] Add a toggle in Buying Settings to check over-billing against quantity or amount (default: Amount)
- [x] Write patch to set the new `billed_qty` for each Purchase Receipt Item

**Considerations:**

- Should the patch check overbilling by Amount (default) or Quantity?
- JHA?