### PR TITLE
fix(package_tag): Filter package tag based on item and batch no

### DIFF
--- a/erpnext/public/js/controllers/stock_controller.js
+++ b/erpnext/public/js/controllers/stock_controller.js
@@ -106,7 +106,7 @@ erpnext.stock.StockController = frappe.ui.form.Controller.extend({
 			}
 			return {
 				filters: filters
-			}
+			};
 		}
 	},
 });

--- a/erpnext/public/js/controllers/stock_controller.js
+++ b/erpnext/public/js/controllers/stock_controller.js
@@ -91,5 +91,22 @@ erpnext.stock.StockController = frappe.ui.form.Controller.extend({
 				frappe.set_route("query-report", "General Ledger");
 			}, __("View"));
 		}
-	}
+	},
+
+	set_query_for_package_tag: function(doc, cdt, cdn) {
+		let item = frappe.get_doc(cdt, cdn);
+		if(!item.item_code) {
+			frappe.throw(__("Please enter Item Code to get Package Tag Number"));
+		} else {
+			let filters = {
+				'item_code': item.item_code
+			}
+			if (item.batch_no) {
+				filters["batch_no"] = item.batch_no
+			}
+			return {
+				filters: filters
+			}
+		}
+	},
 });

--- a/erpnext/public/js/controllers/stock_controller.js
+++ b/erpnext/public/js/controllers/stock_controller.js
@@ -100,9 +100,9 @@ erpnext.stock.StockController = frappe.ui.form.Controller.extend({
 		} else {
 			let filters = {
 				'item_code': item.item_code
-			}
+			};
 			if (item.batch_no) {
-				filters["batch_no"] = item.batch_no
+				filters["batch_no"] = item.batch_no;
 			}
 			return {
 				filters: filters

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -115,6 +115,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			});
 		}
 
+		if(this.frm.fields_dict["items"].grid.get_field('package_tag')) {
+			this.frm.set_query("package_tag", "items", function(doc, cdt, cdn) {
+				return me.set_query_for_package_tag(doc, cdt, cdn);
+			});
+		}
+
 		if(
 			this.frm.docstatus < 2
 			&& this.frm.fields_dict["payment_terms_template"]

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -618,11 +618,9 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 			};
 		});
 
-		if(this.frm.fields_dict["items"].grid.get_field('package_tag')) {
-			this.frm.set_query("package_tag", "items", function(doc, cdt, cdn) {
-				return me.set_query_for_package_tag(doc, cdt, cdn);
-			});
-		}
+		this.frm.set_query("package_tag", "items", function(doc, cdt, cdn) {
+			return me.set_query_for_package_tag(doc, cdt, cdn);
+		});
 
 		if(me.frm.doc.company && erpnext.is_perpetual_inventory_enabled(me.frm.doc.company)) {
 			this.frm.add_fetch("company", "stock_adjustment_account", "expense_account");

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -618,6 +618,12 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 			};
 		});
 
+		if(this.frm.fields_dict["items"].grid.get_field('package_tag')) {
+			this.frm.set_query("package_tag", "items", function(doc, cdt, cdn) {
+				return me.set_query_for_package_tag(doc, cdt, cdn);
+			});
+		}
+
 		if(me.frm.doc.company && erpnext.is_perpetual_inventory_enabled(me.frm.doc.company)) {
 			this.frm.add_fetch("company", "stock_adjustment_account", "expense_account");
 		}


### PR DESCRIPTION
TASK ID: [ASANA](https://app.asana.com/0/1194641031921089/1193997339974189)

Problem statement:

Once a batch number and package tag have been linked the only package tags that should appear in drop are the package tags that batch has been linked to.

solution:
For all buying cycle, selling cycle and stock entry, package tag filter it out based on item.
if there is batch no then item and batch
![1195609431255026 vgX5gzCniNW4Ff7iTVTz_height640](https://user-images.githubusercontent.com/6947417/94258864-28c74700-ff4b-11ea-8d7f-e8e0df7b991e.png)
 