### PR TITLE
feat: cart creation hooks

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -409,8 +409,6 @@ def get_party(user=None):
 	for method in hooks:
 		contact_name = frappe.call(method, contact_name=contact_name) or contact_name
 
-	print("Party contact: %s" % contact_name)
-
 	if contact_name:
 		contact = frappe.get_doc('Contact', contact_name)
 		if contact.links:

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -246,6 +246,7 @@ def decorate_quotation_doc(doc):
 
 def _get_cart_quotation(party=None):
 	'''Return the open Quotation of type "Shopping Cart" or make a new one'''
+	print("_get_cart_quotation")
 	if not party:
 		party = get_party()
 
@@ -273,6 +274,16 @@ def _get_cart_quotation(party=None):
 		qdoc.contact_email = frappe.session.user
 
 		qdoc.flags.ignore_permissions = True
+
+		# Hook: Allows overriding cart quotation creation for shopping cart
+		#       override_shopping_cart_get_quotation(party, qdoc)
+		#
+		#		party: A doctype object(ex: Customer)
+		#		qdoc: Quotation doctype
+		hooks = frappe.get_hooks("override_shopping_cart_get_quotation") or []
+		for method in hooks:
+			frappe.call(method, party=party, qdoc=qdoc)
+
 		qdoc.run_method("set_missing_values")
 		apply_cart_settings(party, qdoc)
 

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -246,7 +246,6 @@ def decorate_quotation_doc(doc):
 
 def _get_cart_quotation(party=None):
 	'''Return the open Quotation of type "Shopping Cart" or make a new one'''
-	print("_get_cart_quotation")
 	if not party:
 		party = get_party()
 
@@ -276,8 +275,11 @@ def _get_cart_quotation(party=None):
 		qdoc.flags.ignore_permissions = True
 
 		# Hook: Allows overriding cart quotation creation for shopping cart
+		#
+		# Signature:
 		#       override_shopping_cart_get_quotation(party, qdoc)
 		#
+		# Args:
 		#		party: A doctype object(ex: Customer)
 		#		qdoc: Quotation doctype
 		hooks = frappe.get_hooks("override_shopping_cart_get_quotation") or []
@@ -392,6 +394,22 @@ def get_party(user=None):
 
 	contact_name = get_contact_name(user)
 	party = None
+
+	# Hook: Allows overriding the contact person used by the shopping cart
+	#
+	# Signature:
+	#       override_shopping_cart_get_party_contact(contact_name)
+	#
+	# Args:
+	#		contact_name: The contact name that will be used to fetch a party
+	#
+	# Returns:
+	#		Hook expects a string or None to override the contact_name
+	hooks = frappe.get_hooks("override_shopping_cart_get_party_contact") or []
+	for method in hooks:
+		contact_name = frappe.call(method, contact_name=contact_name) or contact_name
+
+	print("Party contact: %s" % contact_name)
 
 	if contact_name:
 		contact = frappe.get_doc('Contact', contact_name)


### PR DESCRIPTION
Adds two new hooks to customize quotation creation process:

- override_shopping_cart_get_quotation: Meant to override quotation fields after creation.
- override_shopping_cart_get_party_contact: Meant to override fetching the party associated with a quotation.