### PR TITLE
fix: delete 'Compliance Item' doctype as it's deprecated

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -696,3 +696,4 @@ erpnext.patches.v13_0.set_auto_create_invoice_on_delivery_note
 erpnext.patches.v13_0.update_item_master_doctype_field
 erpnext.patches.v13_0.update_billed_qty_in_purchase_receipt
 erpnext.patches.v13_0.update_subscription
+execute:frappe.delete_doc_if_exists('DocType', 'Compliance Item')


### PR DESCRIPTION
fixes:
`ImportError: Module import failed for Compliance Item (erpnext.compliance.doctype.compliance_item.compliance_item Error: No module named 'erpnext.compliance.doctype.compliance_item.compliance_item'`

The doctype was removed a while back but still appears in the global search causing this issue. This PR removes any trace of the 'Compliance Item' doctype from the app.