### PR TITLE
fix: manufacturing type patch

### DIFF
--- a/erpnext/patches/v13_0/set_manufacturing_types.py
+++ b/erpnext/patches/v13_0/set_manufacturing_types.py
@@ -1,8 +1,12 @@
 import frappe
 
+
 def execute():
+	frappe.reload_doc("manufacturing", "doctype", "bom", force=True)
+	frappe.reload_doc("manufacturing", "doctype", "work_order", force=True)
+	frappe.reload_doc("stock", "doctype", "stock_entry", force=True)
+
 	for dt in ('BOM', 'Work Order', 'Stock Entry'):
-		frappe.reload_doctype(dt)
 		frappe.db.sql("""
 			UPDATE
 				`tab%s`
@@ -10,4 +14,4 @@ def execute():
 				manufacturing_type = "Discrete"
 			WHERE
 				manufacturing_type IS NULL
-		"""% (dt))
+		""" % (dt))


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/rohan/jha/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/rohan/jha/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/rohan/jha/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/rohan/jha/apps/frappe/frappe/commands/site.py", line 266, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/rohan/jha/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/rohan/jha/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/rohan/jha/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/rohan/jha/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/rohan/jha/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/rohan/jha/apps/erpnext/erpnext/patches/v13_0/set_manufacturing_types.py", line 17, in execute
    """ % (dt), debug=True)
  File "/home/rohan/jha/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/rohan/jha/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'manufacturing_type' in 'where clause'")
```