### PR TITLE
fix: force reload BOM doctype

### DIFF
--- a/erpnext/patches/v13_0/set_manufacturing_types.py
+++ b/erpnext/patches/v13_0/set_manufacturing_types.py
@@ -1,8 +1,10 @@
 import frappe
 
 def execute():
+	frappe.reload_doc("manufacturing", "doctype", "BOM", force=1)
+	frappe.reload_doc("manufacturing", "doctype", "Work Order")
+	frappe.reload_doc("manufacturing", "doctype", "Stock Entry")
 	for dt in ('BOM', 'Work Order', 'Stock Entry'):
-		frappe.reload_doctype(dt)
 		frappe.db.sql("""
 			UPDATE
 				`tab%s`


### PR DESCRIPTION
Fixes: `pymysql.err.InternalError: (1054, "Unknown column 'manufacturing_type' in 'where clause'")`