### PR TITLE
fix: data import for item

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -699,3 +699,4 @@ erpnext.patches.v13_0.update_billed_qty_in_purchase_receipt
 erpnext.patches.v13_0.update_subscription
 execute:frappe.delete_doc_if_exists('DocType', 'Compliance Item')
 erpnext.patches.v13_0.harvest_stock_entry_type_added
+execute:frappe.delete_doc_if_exists('Custom Field', 'Stock Settings-autoname_item')

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -129,6 +129,7 @@ frappe.ui.form.on("Item", {
 		});
 
 		frm.toggle_reqd('customer', frm.doc.is_customer_provided_item ? 1 : 0);
+		frm.toggle_reqd('item_code', true);
 	},
 
 	validate: function(frm){

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -22,6 +22,10 @@ from frappe.website.render import clear_cache
 from frappe.website.website_generator import WebsiteGenerator
 
 from six import iteritems
+from erpnext.utilities.utils import get_abbr
+from erpnext import get_default_company
+from erpnext.accounts.utils import get_company_default
+from frappe.utils import cstr
 
 
 class DuplicateReorderRows(frappe.ValidationError):
@@ -67,6 +71,9 @@ class Item(WebsiteGenerator):
 				from frappe.model.naming import set_name_by_naming_series
 				set_name_by_naming_series(self)
 				self.item_code = self.name
+
+		if frappe.db.get_single_value("Stock Settings", "autoname_item"):
+			self.item_code = custom_autoname(self)
 
 		self.item_code = strip(self.item_code)
 		self.name = self.item_code
@@ -1132,3 +1139,30 @@ def toggle_variants_website_display(item_name, value):
 def on_doctype_update():
 	# since route is a Text column, it needs a length for indexing
 	frappe.db.add_index("Item", ["route(500)"])
+
+def custom_autoname(doc):
+	"""
+		Item Code = a + b + c + d + e, where
+			a = abbreviated Company; all caps.
+			b = abbreviated Brand; all caps.
+			c = abbreviated Item Group; all caps.
+			d = abbreviated Item Name; all caps.
+			e = variant ID number; has to be incremented.
+	"""
+	# Get abbreviations
+	company_abbr = get_company_default(get_default_company(), "abbr")
+	brand_abbr = get_abbr(doc.brand, max_length=len(company_abbr))
+	brand_abbr = brand_abbr if company_abbr != brand_abbr else None
+	item_group_abbr = get_abbr(doc.item_group)
+	item_name_abbr = get_abbr(doc.item_name, 3)
+
+	params = list(filter(None, [company_abbr, brand_abbr, item_group_abbr, item_name_abbr]))
+	item_code = "-".join(params)
+
+		# Get count
+	count = len(frappe.get_all("Item", filters={"name": ["like", "%{}%".format(item_code)]}))
+
+	if count > 0:
+		item_code = "-".join([item_code, cstr(count + 1)])
+
+	return item_code

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "creation": "2013-06-24 16:37:54",
  "description": "Settings",
  "doctype": "DocType",
@@ -19,6 +18,7 @@
   "section_break_7",
   "auto_insert_price_list_rate_if_missing",
   "allow_negative_stock",
+  "autoname_item",
   "column_break_10",
   "automatically_set_serial_nos_based_on_fifo",
   "automatically_set_batch_nos_based_on_fifo",
@@ -197,13 +197,18 @@
    "fieldname": "automatically_set_batch_nos_based_on_fifo",
    "fieldtype": "Check",
    "label": "Automatically Set Batch Nos based on FIFO"
+  },
+  {
+   "default": "0",
+   "fieldname": "autoname_item",
+   "fieldtype": "Check",
+   "label": "Suggest Item Code"
   }
  ],
  "icon": "icon-cog",
  "idx": 1,
  "issingle": 1,
- "links": [],
- "modified": "2019-12-25 22:56:33.206204",
+ "modified": "2020-10-22 05:08:55.770976",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils.html_utils import clean_html
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 class StockSettings(Document):
 	def validate(self):
@@ -33,6 +34,9 @@ class StockSettings(Document):
 		self.validate_warehouses()
 		self.cant_change_valuation_method()
 		self.validate_clean_description_html()
+
+	def on_update(self):
+		toggle_item_code_reqd(self)
 
 	def validate_warehouses(self):
 		warehouse_fields = ["default_warehouse", "sample_retention_warehouse"]
@@ -61,10 +65,15 @@ class StockSettings(Document):
 			# changed to text
 			frappe.enqueue('erpnext.stock.doctype.stock_settings.stock_settings.clean_all_descriptions', now=frappe.flags.in_test)
 
-
 def clean_all_descriptions():
 	for item in frappe.get_all('Item', ['name', 'description']):
 		if item.description:
 			clean_description = clean_html(item.description)
 		if item.description != clean_description:
 			frappe.db.set_value('Item', item.name, 'description', clean_description)
+
+def toggle_item_code_reqd(settings):
+	if settings:
+		make_property_setter("Item", "item_code", "reqd", 1, "Check")
+	else:
+		frappe.delete_doc_if_exists("Property Setter", "Item-item_code-reqd")

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -73,7 +73,7 @@ def clean_all_descriptions():
 			frappe.db.set_value('Item', item.name, 'description', clean_description)
 
 def toggle_item_code_reqd(settings):
-	if settings:
+	if settings.autoname_item:
 		make_property_setter("Item", "item_code", "reqd", 1, "Check")
 	else:
 		frappe.delete_doc_if_exists("Property Setter", "Item-item_code-reqd")

--- a/erpnext/utilities/utils.py
+++ b/erpnext/utilities/utils.py
@@ -1,0 +1,40 @@
+from six import string_types
+
+def get_abbr(txt, max_length=2):
+	"""
+		Extract abbreviation from the given string as:
+			- Single-word strings abbreviate to the letters of the string, upto the max length
+			- Multi-word strings abbreviate to the initials of each word, upto the max length
+
+	Args:
+		txt (str): The string to abbreviate
+		max_length (int, optional): The max length of the abbreviation. Defaults to 2.
+
+	Returns:
+		str: The abbreviated string, in uppercase
+	"""
+
+	if not txt:
+		return
+
+	if not isinstance(txt, string_types):
+		try:
+			txt = str(txt)
+		except:
+			return
+
+	abbr = ""
+	words = txt.split(" ")
+
+	if len(words) > 1:
+		for word in words:
+			if len(abbr) >= max_length:
+				break
+
+			if word.strip():
+				abbr += word.strip()[0]
+	else:
+		abbr = txt[:max_length]
+
+	abbr = abbr.upper()
+	return abbr


### PR DESCRIPTION
- Data import was breaking since `item_code` is a mandatory field and when `autoname_item` is selected in Stock Settings, Data Import should ignore mandatory for `item_code` and run `autoname` function to generate the `item_code`.

Co-authored by: @sahil28297 