### PR TITLE
fix:sales invoice refrence in delivery note

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -311,6 +311,9 @@ class DeliveryNote(SellingController):
 
 				new_invoices.append(get_link_to_form("Sales Invoice", invoice.name))
 
+				for item in self.items:
+  					item.against_sales_invoice = invoice.name
+
 		if new_invoices:
 			new_invoices = ", ".join(str(invoice) for invoice in new_invoices)
 			frappe.msgprint(_("The following Sales Invoice(s) were automatically created: {0}".format(new_invoices)))

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -585,8 +585,7 @@ def update_delivery_trip_status(payment_amount, sales_invoice):
 		trip_doc = frappe.get_doc("Delivery Trip", trip)
 		for stop in trip_doc.delivery_stops:
 			if stop.name in delivery_stops:
-				stop.visited = True
-				stop.paid_amount = payment_amount
+				frappe.db.set_value("Delivery Stop", stop.name, "paid_amount", payment_amount)
+				frappe.db.set_value("Delivery Stop", stop.name, "visited", 1)
 				if stop.delivery_note:
 					frappe.db.set_value("Delivery Note", stop.delivery_note, "status", "Completed")
-		trip_doc.save()


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. want to merge in develop 
 2. PR name : https://app.asana.com/0/1190044176320816/1198882929334742
 3 Description : setting auto generated sales reference into delivery note item of field of (against_sales_invoice) so we can fetch this reference into delivery trip
