### PR TITLE
fix: filtering out 'Left' status employees from Training Event

### DIFF
--- a/erpnext/hr/doctype/training_event/training_event.js
+++ b/erpnext/hr/doctype/training_event/training_event.js
@@ -2,6 +2,15 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Training Event', {
+	setup: function (frm) {
+		frm.set_query('employee', 'employees', function () {
+			return {
+				filters: {
+					"status": "Active"
+				}
+			};
+		});
+	},
 	onload_post_render: function(frm) {
 		frm.get_field("employees").grid.set_multiple_add("employee");
 	},


### PR DESCRIPTION
[TASK](https://app.asana.com/0/1199205301822135/1199207223388229/f)

![left_employee_training_filter](https://user-images.githubusercontent.com/58166671/100324530-6567fb00-2fed-11eb-8b80-8ae53ea4de8c.gif)
