### PR TITLE
fix: permission destroyed plant log

### DIFF
--- a/erpnext/agriculture/doctype/destroyed_plant_log/destroyed_plant_log.json
+++ b/erpnext/agriculture/doctype/destroyed_plant_log/destroyed_plant_log.json
@@ -59,13 +59,14 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2020-11-01 22:06:08.372627",
+ "modified": "2020-11-30 01:06:46.072580",
  "modified_by": "Administrator",
  "module": "Agriculture",
  "name": "Destroyed Plant Log",
  "owner": "Administrator",
  "permissions": [
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -75,6 +76,7 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   },
   {


### PR DESCRIPTION
Give 'System manager' a 'submit' and 'cancel' permission in 'Destroyed Plant Log' doctype.