### PR TITLE
feat: Allocated amount based on order qty for advance payment

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1048,7 +1048,7 @@
    "label": "Allocate Advances Automatically (FIFO)"
   },
   {
-   "depends_on": "eval:!doc.allocate_advances_automatically",
+   "depends_on": "eval:!doc.allocate_advances_automatically && !doc.allocate_advances_based_on_quantities",
    "fieldname": "get_advances",
    "fieldtype": "Button",
    "label": "Get Advances Received",
@@ -1600,7 +1600,7 @@
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2020-12-09 19:56:56.763596",
+ "modified": "2020-12-13 22:43:56.201272",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -118,6 +118,7 @@
   "total_advance",
   "outstanding_amount",
   "advances_section",
+  "allocate_advances_based_on_quantities",
   "allocate_advances_automatically",
   "get_advances",
   "advances",
@@ -1588,12 +1589,18 @@
    "fieldname": "signature",
    "fieldtype": "Signature",
    "label": "Signature"
+  },
+  {
+   "default": "0",
+   "fieldname": "allocate_advances_based_on_quantities",
+   "fieldtype": "Check",
+   "label": "Allocate Advances Based on Quantities"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2020-11-04 03:38:05.081515",
+ "modified": "2020-12-09 19:56:56.763596",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -471,13 +471,20 @@ class AccountsController(TransactionBase):
 	def set_advances(self):
 		"""Returns list of advances against Account, Party, Reference"""
 
-		res = self.get_advance_entries()
+		if self.allocate_advances_based_on_quantities:
+			res = self.get_advance_entries(include_unallocated=False)
+		else:
+			res = self.get_advance_entries()
 
 		self.set("advances", [])
 		advance_allocated = 0
+		print("-------------------------------------------------------------------", res)
 		for d in res:
 			if d.against_order:
-				allocated_amount = flt(d.amount)
+				if self.allocate_advances_based_on_quantities:
+					allocated_amount = flt(self.total_qty / 5000) * d.amount
+				else:
+					allocated_amount = flt(d.amount)
 			else:
 				amount = self.rounded_total or self.grand_total
 				allocated_amount = min(amount - advance_allocated, d.amount)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -478,11 +478,12 @@ class AccountsController(TransactionBase):
 
 		self.set("advances", [])
 		advance_allocated = 0
-		print("-------------------------------------------------------------------", res)
 		for d in res:
 			if d.against_order:
 				if self.allocate_advances_based_on_quantities:
-					allocated_amount = flt(self.total_qty / 5000) * d.amount
+					# formula for calculating allocated amount = (Fullfilled qty / Order Qty) * original_advance_paid_amount
+					order_qty = frappe.db.get_value("Sales Order", filters={"name":d.against_order}, fieldname=["total_qty"])
+					allocated_amount = flt(self.total_qty / order_qty) * d.total_allocated_amount
 				else:
 					allocated_amount = flt(d.amount)
 			else:
@@ -1009,7 +1010,7 @@ def get_advance_journal_entries(party_type, party, party_account, amount_field,
 		select
 			"Journal Entry" as reference_type, t1.name as reference_name,
 			t1.remark as remarks, t2.{0} as amount, t2.name as reference_row,
-			t2.reference_name as against_order
+			t2.reference_name as against_order, t1.total_amount as total_allocated_amount
 		from
 			`tabJournal Entry` t1, `tabJournal Entry Account` t2
 		where
@@ -1042,7 +1043,7 @@ def get_advance_payment_entries(party_type, party, party_account, order_doctype,
 			select
 				"Payment Entry" as reference_type, t1.name as reference_name,
 				t1.remarks, t2.allocated_amount as amount, t2.name as reference_row,
-				t2.reference_name as against_order, t1.posting_date
+				t2.reference_name as against_order, t1.posting_date, t1.total_allocated_amount
 			from `tabPayment Entry` t1, `tabPayment Entry Reference` t2
 			where
 				t1.name = t2.parent and t1.{0} = %s and t1.payment_type = %s

--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -65,7 +65,19 @@ frappe.ui.form.on(cur_frm.doctype, {
 				}
 			})
 		}
-	}
+	},
+	allocate_advances_based_on_quantities: function(frm) {
+		if(frm.doc.allocate_advances_based_on_quantities) {
+			frappe.call({
+				doc: frm.doc,
+				method: "set_advances",
+				callback: function(r, rt) {
+					refresh_field("advances");
+				}
+			})
+		}
+	},
+
 });
 
 frappe.ui.form.on('Sales Invoice Payment', {

--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -48,7 +48,6 @@ frappe.ui.form.on(cur_frm.doctype, {
 			frm.get_docfield("taxes", "rate").reqd = 0;
 			frm.get_docfield("taxes", "tax_amount").reqd = 0;
 		}
-
 	},
 	taxes_on_form_rendered: function(frm) {
 		erpnext.taxes.set_conditional_mandatory_rate_or_amount(frm.open_grid_row());
@@ -57,27 +56,25 @@ frappe.ui.form.on(cur_frm.doctype, {
 
 	allocate_advances_automatically: function(frm) {
 		if(frm.doc.allocate_advances_automatically) {
-			frappe.call({
-				doc: frm.doc,
-				method: "set_advances",
-				callback: function(r, rt) {
-					refresh_field("advances");
-				}
-			})
-		}
-	},
-	allocate_advances_based_on_quantities: function(frm) {
-		if(frm.doc.allocate_advances_based_on_quantities) {
-			frappe.call({
-				doc: frm.doc,
-				method: "set_advances",
-				callback: function(r, rt) {
-					refresh_field("advances");
-				}
-			})
+			frm.trigger("set_advances");
 		}
 	},
 
+	allocate_advances_based_on_quantities: function(frm) {
+		if(frm.doc.allocate_advances_based_on_quantities) {
+			frm.trigger("set_advances");
+		}
+	},
+
+	set_advances: function(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: "set_advances",
+			callback: function(r, rt) {
+				refresh_field("advances");
+			}
+		});
+	}
 });
 
 frappe.ui.form.on('Sales Invoice Payment', {


### PR DESCRIPTION
TASK ID : [ASANA](https://app.asana.com/0/1192407894480744/1199117996091237)
Scenario:
Formula to calculate allocated amount = (fulfiled qty/order qty ) * advance_paid_amount
1. a sales Order for 5000 and amount $ 123,750.00 and so booked for 40% advance 495000
2. system should auto calculate the allocated amount for qty
ex. 
1.Sales invoice for 1000 qty on selection for allocation based on qty it allocates 9900   :       (1000/5000)*49500 
2. Sales Invoice for 2000 qty on selection for allocation based on qty it allocates 19800 :      (2000/5000)*49500
3. Sales Invoice for 2000 qty  on selection for allocation based on qty it allocates 19800 :     (2000/5000)*49500
so total invoice qty 5000 it gets allocated amount based on a formula to advance payment

Gif Added for Reference:
[asana](https://app.asana.com/0/1199385963941334/1199117996091237)

