### PR TITLE
fix: auto fetch Batch No from Source Package Tag to Pick List Item

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -195,14 +195,14 @@ frappe.ui.form.on('Pick List Item', {
 		let row = frappe.get_doc(cdt, cdn);
 		frappe.model.set_value(cdt, cdn, 'stock_qty', row.qty * row.conversion_factor);
 	},
-	package_tag: (frm, cdt, cdn) => {
+	source_package_tag: (frm, cdt, cdn) => {
 		const row = frm.selected_doc || locals[cdt][cdn];
-		if (row.package_tag) {
-			frappe.db.get_value("Package Tag", { "name": row.package_tag }, "batch_no", (r) => {
+		if (row.source_package_tag) {
+			frappe.db.get_value("Package Tag", { "name": row.source_package_tag }, "batch_no", (r) => {
 				if (r && r.batch_no) {
 					// check if a different batch already exists
 					if (row.batch_no && row.batch_no != r.batch_no) {
-						frappe.throw(__(`The "${row.package_tag}" tag is linked to a different batch (${r.batch_no})`));
+						frappe.throw(__("The {0} tag is linked to a different batch {1}.", [row.source_package_tag, r.batch_no]));
 					} else {
 						frappe.model.set_value(cdt, cdn, "batch_no", r.batch_no);
 					}


### PR DESCRIPTION
[TASK](https://app.asana.com/0/1192407897953440/1199630640041901/f)
- on selection of `source_package_tag` it will auto fetch batch no. instead of on selection of `package_tag`

![pick_list_batch_no](https://user-images.githubusercontent.com/58166671/102460260-bf983100-406c-11eb-94f3-5994165188cb.gif)
