### PR TITLE
feat: Adds "Order For" feature for sales person.

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -57,7 +57,10 @@ on_logout = "erpnext.shopping_cart.utils.clear_cart_count"
 treeviews = ['Account', 'Cost Center', 'Warehouse', 'Item Group', 'Customer Group', 'Sales Person', 'Territory', 'Assessment Group', 'Department']
 
 # website
-update_website_context = ["erpnext.shopping_cart.utils.update_website_context", "erpnext.education.doctype.education_settings.education_settings.update_website_context"]
+update_website_context = [
+	"erpnext.shopping_cart.utils.update_website_context", 
+	"erpnext.education.doctype.education_settings.education_settings.update_website_context"
+]
 my_account_context = "erpnext.shopping_cart.utils.update_my_account_context"
 
 email_append_to = ["Job Applicant", "Lead", "Opportunity", "Issue"]

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -50,7 +50,7 @@ on_session_creation = [
 	"erpnext.shopping_cart.utils.set_cart_count"
 ]
 
-on_session_start = "erpnext.selling.utils.initialise_order_for "
+on_session_start = "erpnext.selling.utils.initialise_order_for"
 
 on_logout = "erpnext.shopping_cart.utils.clear_cart_count"
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -49,6 +49,9 @@ on_session_creation = [
 	"erpnext.portal.utils.create_customer_or_supplier",
 	"erpnext.shopping_cart.utils.set_cart_count"
 ]
+
+on_session_start = "erpnext.selling.utils.on_session_start"
+
 on_logout = "erpnext.shopping_cart.utils.clear_cart_count"
 
 treeviews = ['Account', 'Cost Center', 'Warehouse', 'Item Group', 'Customer Group', 'Sales Person', 'Territory', 'Assessment Group', 'Department']

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -50,7 +50,7 @@ on_session_creation = [
 	"erpnext.shopping_cart.utils.set_cart_count"
 ]
 
-on_session_start = "erpnext.selling.utils.on_session_start"
+on_session_start = "erpnext.selling.utils.initialise_order_for "
 
 on_logout = "erpnext.shopping_cart.utils.clear_cart_count"
 

--- a/erpnext/public/scss/website.scss
+++ b/erpnext/public/scss/website.scss
@@ -82,3 +82,26 @@
 .place-order-container {
 	text-align: right;
 }
+
+/* Order For Feature */
+
+.navbar { 
+	.user-identifier {
+		display: inline-flex;
+		flex-direction: column;
+		white-space: nowrap;
+	}
+	.user-identifier .full-name {
+		line-height: .9rem;
+		font-size: 1.2rem;
+		white-space: nowrap;
+	}
+	.user-identifier .for {
+		font-size: .8rem;
+	}
+	.user-identifier .order-for-contact {
+		font-size: .8rem;
+		margin: 0;
+		white-space: nowrap;
+	}
+}

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -165,6 +165,56 @@ frappe.ui.form.on("Customer", {
 				erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name);
 			}, __('Create'));
 
+			// only one of these roles is allowed to use these feature
+			if ( frappe.user.has_role("Sales User") || frappe.user.has_role("Sales Manager") || frappe.user.has_role("System Manager") || frappe.user.has_role("Administrator")) {
+				frappe.call({
+					method: "frappe.client.get", 
+					args: {
+						"doctype": "Shopping Cart Settings",
+						"name": "Shopping Cart Settings"
+					}
+				}).then((data) => {
+
+					const shopping_cart_settings = data.message;
+
+					if ( shopping_cart_settings.allow_order_for ) {
+						frm.add_custom_button(__('Order For Customer'), function() {
+							let windowTarget = window;
+							if  ( shopping_cart_settings.order_for_open_in_tab ) {
+								windowTarget = window.open("", "_blank");
+								// Create a new window as a pop under to redirect backend user to the frontend without closing the current page.
+								windowTarget.blur();
+								// Then focus back on current window until we have a successful callback.
+								window.focus();
+							}
+
+							frappe.call({
+								method: "erpnext.utilities.order_for.set_website_customer",
+								args: { customer_name: frm.doc.name },
+								freeze: true,
+								callback: function(data) {
+									if ( data.message == "Success" ) {
+										if  ( shopping_cart_settings.order_for_open_in_tab ) {
+											// move focus back to pop under
+											window.blur();
+											windowTarget.focus();
+										}
+										// redirect pop under to website
+										windowTarget.location.href = data.landing_url || "/";
+									} else {
+										if  ( shopping_cart_settings.order_for_open_in_tab ) {
+												// close pop under on error
+											windowTarget.close();
+										}
+										frappe.msgprint(data.message);
+									}
+								}
+							})
+						});
+					}
+				});	
+			}
+
 			// indicator
 			erpnext.utils.set_party_dashboard_indicators(frm);
 

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -200,7 +200,7 @@ frappe.ui.form.on("Customer", {
 											windowTarget.focus();
 										}
 										// redirect pop under to website
-										windowTarget.location.href = data.landing_url || "/";
+										windowTarget.location.href = shopping_cart_settings.order_for_landing_url || "/";
 									} else {
 										if  ( shopping_cart_settings.order_for_open_in_tab ) {
 												// close pop under on error

--- a/erpnext/selling/utils/__init__.py
+++ b/erpnext/selling/utils/__init__.py
@@ -1,0 +1,1 @@
+from erpnext.selling.utils.order_for import *

--- a/erpnext/selling/utils/order_for.py
+++ b/erpnext/selling/utils/order_for.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _dict
 from erpnext.shopping_cart.cart import get_party
 
-def on_session_start():
+def initialise_order_for ():
 	"""Initializes the "order for" feature which allows a backend user to use the
 	shopping cart in behalf of another user"""
 

--- a/erpnext/selling/utils/order_for.py
+++ b/erpnext/selling/utils/order_for.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _dict
 from erpnext.shopping_cart.cart import get_party
 
-def initialise_order_for ():
+def initialise_order_for():
 	"""Initializes the "order for" feature which allows a backend user to use the
 	shopping cart in behalf of another user"""
 
@@ -10,6 +10,8 @@ def initialise_order_for ():
 	frappe.session.data["order_for"] = _dict(frappe.session.data.get("order_for", {}))
 	order_for = frappe.session.data.order_for
 
+	if frappe.session.user in ("Guest", "Administrator"):
+		return
 	# Set default customer
 	if not order_for.get("customer_name") and frappe.session.user not in ("Guest", "Administrator"):
 		contact = frappe.get_doc("Contact", {"email_id": frappe.session.user})
@@ -17,7 +19,6 @@ def initialise_order_for ():
 		for link in contact.links:
 			if link.link_doctype == "Customer":
 				customer_links.append(link)
-		
 		if len(customer_links) == 1:
 			order_for["customer_name"] = customer_links[0].link_name
 			order_for["customer_primary_contact_name"] = contact.name
@@ -32,5 +33,4 @@ def initialise_order_for ():
 			order_for["customer_name"] = customer.name
 
 		order_for["customer_group"] = customer.customer_group
-
 

--- a/erpnext/selling/utils/order_for.py
+++ b/erpnext/selling/utils/order_for.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe import _dict
+from erpnext.shopping_cart.cart import get_party
+
+def on_session_start():
+	"""Initializes the "order for" feature which allows a backend user to use the
+	shopping cart in behalf of another user"""
+
+	# Initialize frappe.session.data.order_for
+	if "order_for" not in frappe.session.data:
+		frappe.session.data["order_for"] = _dict({})
+
+	order_for = frappe.session.data.order_for
+
+	# Keep customer info up to date on every session start
+	customer = get_party()
+	if customer and customer.doctype == "Customer":
+		# no reason to set customer_name again as get_party expects
+		# customer_name to exists to set user from the "order for" feature
+		# otherwise vanilla path is executed a the true customer is returned.
+		if order_for.get("customer_name"):
+			order_for.set("customer_name", customer.name)
+
+		order_for.set("customer_group", customer.customer_group)
+

--- a/erpnext/selling/utils/order_for.py
+++ b/erpnext/selling/utils/order_for.py
@@ -11,7 +11,7 @@ def on_session_start():
 	order_for = frappe.session.data.order_for
 
 	# Set default customer
-	if not order_for.get("customer_name"):
+	if not order_for.get("customer_name") and frappe.session.user not in ("Guest", "Administrator"):
 		contact = frappe.get_doc("Contact", {"email_id": frappe.session.user})
 		customer_links = []
 		for link in contact.links:

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -270,6 +270,20 @@ def _get_cart_quotation(party=None):
 
 		qdoc.flags.ignore_permissions = True
 
+		# Order For feature:
+		if "order_for" in frappe.session.data:
+			customer_name = frappe.session.data.order_for.get("customer_name")
+
+			if customer_name:
+				# override contact person
+				primary_contact = frappe.session.data.order_for.get("customer_primary_contact_name")
+
+				qdoc.contact_person = primary_contact
+				qdoc.contact_email = frappe.get_value("Contact", primary_contact, "email_id")
+
+				# override customer
+				qdoc.party_name = customer_name
+
 		# Hook: Allows overriding cart quotation creation for shopping cart
 		#
 		# Signature:
@@ -396,8 +410,7 @@ def get_party(user=None):
 		customer_name = frappe.session.data.order_for.get("customer_name")
 		
 		if customer_name and "customer_primary_contact_name" in frappe.session.data.order_for:
-			primary_contact = frappe.session.data.order_for.customer_primary_contact_name
-			contact_name primary_contact
+			contact_name = frappe.session.data.order_for.customer_primary_contact_name
 
 	# Hook: Allows overriding the contact person used by the shopping cart
 	#

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -391,6 +391,14 @@ def get_party(user=None):
 	contact_name = get_contact_name(user)
 	party = None
 
+	# Order For feature. Sets current customer's primary contact for this session.
+	if "order_for" in frappe.session.data:
+		customer_name = frappe.session.data.order_for.get("customer_name")
+		
+		if customer_name and "customer_primary_contact_name" in frappe.session.data.order_for:
+			primary_contact = frappe.session.data.order_for.customer_primary_contact_name
+			contact_name primary_contact
+
 	# Hook: Allows overriding the contact person used by the shopping cart
 	#
 	# Signature:

--- a/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.json
+++ b/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "creation": "2013-06-19 15:57:32",
  "description": "Default settings for Shopping Cart",
  "doctype": "DocType",
@@ -26,6 +25,13 @@
   "enable_checkout",
   "column_break_20",
   "payment_success_url",
+  "sb_order_for",
+  "allow_order_for",
+  "stop_order_for_behavior",
+  "stop_order_for_url",
+  "sb_order_for_cb1",
+  "order_for_open_in_tab",
+  "order_for_landing_url",
   "section_break_22",
   "gateways"
  ],
@@ -165,14 +171,56 @@
    "fieldtype": "Table",
    "label": "Gateways",
    "options": "Shopping Cart Payment Gateway"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_order_for",
+   "fieldtype": "Check",
+   "label": "Allow Sales Person to Order for Customer"
+  },
+  {
+   "depends_on": "eval:doc.allow_order_for == 1 && doc.stop_order_for_behavior == \"Redirect\"",
+   "fieldname": "stop_order_for_url",
+   "fieldtype": "Data",
+   "label": "Stop Order For Url"
+  },
+  {
+   "default": "/products",
+   "depends_on": "eval:doc.allow_order_for == 1",
+   "fieldname": "order_for_landing_url",
+   "fieldtype": "Data",
+   "label": "Order For Landing Url"
+  },
+  {
+   "default": "Reload",
+   "depends_on": "eval:doc.allow_order_for == 1",
+   "fieldname": "stop_order_for_behavior",
+   "fieldtype": "Select",
+   "label": "Stop Order For Behaviour",
+   "options": "Reload\nRedirect\nBack to Customer Record"
+  },
+  {
+   "fieldname": "sb_order_for",
+   "fieldtype": "Section Break",
+   "label": "Order For"
+  },
+  {
+   "fieldname": "sb_order_for_cb1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.allow_order_for == 1",
+   "fieldname": "order_for_open_in_tab",
+   "fieldtype": "Check",
+   "label": "Load Url In New Tab"
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 1,
  "issingle": 1,
- "links": [],
- "modified": "2020-06-10 16:39:21.768721",
- "modified_by": "Administrator",
+ "modified": "2020-12-18 11:34:50.612390",
+ "modified_by": "forellana@digithinkit.com",
  "module": "Shopping Cart",
  "name": "Shopping Cart Settings",
  "owner": "Administrator",

--- a/erpnext/shopping_cart/utils.py
+++ b/erpnext/shopping_cart/utils.py
@@ -38,6 +38,21 @@ def update_website_context(context):
 		"shopping_cart_count": shopping_cart_count
 	})
 
+	# Order for feature:
+	if "order_for" in frappe.session.data:
+		customer_name = frappe.session.data.order_for.get("customer_name")
+	
+		if customer_name:
+			customer = frappe.get_doc("Customer", customer_name)
+			primary_contact = frappe.session.data.order_for.get("customer_primary_contact_name")
+
+			context.update({"session_customer": customer})
+
+			if primary_contact:
+				contact = frappe.get_doc("Contact", primary_contact)
+				context.update({"session_customer_primary_contact": contact})
+
+
 def check_customer_or_supplier():
 	if frappe.session.user:
 		contact_name = frappe.get_value("Contact", {"email_id": frappe.session.user})

--- a/erpnext/templates/includes/navbar/navbar_login.html
+++ b/erpnext/templates/includes/navbar/navbar_login.html
@@ -1,0 +1,33 @@
+<!-- post login tools -->
+{% if frappe.session.user != 'Guest' %}
+<li class="nav-item dropdown logged-in" id="website-post-login" data-label="website-post-login" style="display: none">
+	<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
+		<span class="user-image-wrapper"></span>
+		<span class="user-identifier">
+			<span class="full-name"></span>
+			{% if session_customer_primary_contact %}
+			<span class="order-for-contact"><span class="for">for: </span>{{ session_customer_primary_contact.first_name }} {{ session_customer_primary_contact.last_name or ""}}</span>
+			{% endif %}
+		</span>
+		<b class="caret"></b>
+	</a>
+	<ul class="dropdown-menu dropdown-menu-right" role="menu">
+		{% if session_customer_primary_contact %}
+		<a class="dropdown-item order-for-contact-logout" href="#" rel="nofollow">Stop order for <span>{{ session_customer_primary_contact.first_name }} {{ session_customer_primary_contact.last_name or ""}}</span></a>
+		{% endif %}		{%- for child in post_login -%}
+		{%- if child.url -%}
+		<a class="dropdown-item" href="{{ child.url | abs_url }}" {{ child.target or '' }} rel="nofollow">
+			{{ child.label }}
+		</a>
+		{%- endif -%}
+		{%- endfor -%}
+		<a class="dropdown-item switch-to-desk hidden" href="/desk">{{ _('Switch To Desk') }}</a>
+	</ul>
+</li>
+{% endif %}
+
+{% if not hide_login %}
+<li class="nav-item">
+	<a class="nav-link btn-login-area" href="/login">{{ _("Login") }}</a>
+</li>
+{% endif %}

--- a/erpnext/utilities/order_for.py
+++ b/erpnext/utilities/order_for.py
@@ -1,0 +1,81 @@
+import frappe
+from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings import get_shopping_cart_settings
+
+@frappe.whitelist(allow_guest=False)
+def set_website_customer(customer_name, primary_contact=None):
+
+	# Find primary contact of this customer if one is not passed
+	if not primary_contact:
+		primary_contact = find_customer_primary_contact(customer_name)
+
+	# make sure customer has at least a contact
+	if not primary_contact:
+		return "Customer does not have a primary contact. Please set one before starting an order."
+
+	frappe.session.data.order_for["customer_name"] = customer_name
+	frappe.session.data.order_for["customer_primary_contact_name"] = primary_contact
+
+	return "Success"
+
+@frappe.whitelist(allow_guest=True)
+def reset_website_customer():
+	settings = get_shopping_cart_settings()
+
+	customer_name = frappe.session.data.order_for.get("customer_name")
+
+	if frappe.session.data.order_for.get("customer_name"):
+		del frappe.session.data.order_for["customer_name"]
+	if frappe.session.data.order_for.get("customer_primary_contact_name"):
+		del frappe.session.data.order_for["customer_primary_contact_name"]
+
+	if settings.get("stop_order_for_behavior") == "Reload":
+		url = "Reload"
+	if settings.get("stop_order_for_behavior") == "Back to Customer Record" and customer_name:
+		url = "/desk#Form/Customer/{}".format(customer_name)
+	else:
+		url = settings.get("stop_order_for_url", "") or "Reload"
+
+	# Hook: Allows overriding the routing url after a user resets the website customer
+	#
+	# Signature:
+	#       override_stop_order_for_url(url)
+	#
+	# Args:
+	#		url: The current route
+	#
+	# Returns:
+	#		Hook expects a string or None to override the route
+	hooks = frappe.get_hooks("override_stop_order_for_url") or []
+	for method in hooks:
+		url = frappe.call(method, url=url) or url
+
+	if not url:
+		url = "Reload"
+
+	return url
+
+def find_customer_primary_contact(customer_name):
+	primary_contact = frappe.get_value("Customer", customer_name, "customer_primary_contact")
+
+	if not primary_contact:
+		contacts = find_parent_dynamic_links("Contact", "links", "Customer", customer_name)
+		for contact in contacts:
+			is_primary = frappe.get_value("Contact", contact, "is_primary_contact")
+			if is_primary:
+				primary_contact = contact
+				break
+		
+		if not primary_contact and len(contacts) > 0:
+			primary_contact = contacts[0]
+
+	return primary_contact
+
+def find_parent_dynamic_links(parent_dt, parent_field, link_dt, link_dn):
+	return [r[0] for r in frappe.get_all("Dynamic Link", filters={
+		"parenttype": parent_dt, 
+		"parentfield": parent_field,
+		"link_doctype": link_dt, 
+		"link_name": link_dn
+	}, 
+	fields=['parent'],
+	as_list=1)]


### PR DESCRIPTION
Features:

- Adds a "Order For Customer" button on the Customer form doctype if "Allow Sales Person To Order For Customer" flag is enabled in "Shopping Cart Settings" doctype
- Upon clicking the "Order For" button user is redirect to a predefined url on the same window or tab depending on shopping cart settings
- To stop the "Order For" functionality, user can open their account menu drop down and click "Stop Ordering for ..." to be either redirected back to the customer form, reload the same page or redirect to another page depending on shopping cart settings.
- Adds a hook to allow overriding this "stop order for" url

Screenshots:

The Shopping Cart Settings fields:

![order_for_settings](https://user-images.githubusercontent.com/1656249/102639666-604b2700-4127-11eb-840a-9c0f0d3b31ce.gif)

Demo ordering for a customer and coming back to the same record on stop:

![order_for_demo1](https://user-images.githubusercontent.com/1656249/102639990-d64f8e00-4127-11eb-9d81-de82f8da4af7.gif)

Demo ordering for a customer on a different tab and reloading on stop:

![order_for_demo2](https://user-images.githubusercontent.com/1656249/102640415-6b528700-4128-11eb-83bb-025f093d4fa4.gif)
