### PR TITLE
fix: Adds missing coupon_code reference on sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -100,6 +100,7 @@
   "loyalty_redemption_account",
   "loyalty_redemption_cost_center",
   "section_break_49",
+  "coupon_code",
   "apply_discount_on",
   "base_discount_amount",
   "column_break_51",
@@ -1595,13 +1596,19 @@
    "fieldname": "allocate_advances_based_on_quantities",
    "fieldtype": "Check",
    "label": "Allocate Advances Based on Quantities"
+  },
+  {
+   "fieldname": "coupon_code",
+   "fieldtype": "Link",
+   "label": "Coupon Code",
+   "options": "Coupon Code"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2020-12-13 22:43:56.201272",
- "modified_by": "Administrator",
+ "modified": "2020-12-18 19:12:42.440076",
+ "modified_by": "forellana@digithinkit.com",
  "module": "Accounts",
  "name": "Sales Invoice",
  "name_case": "Title Case",

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -57,14 +57,16 @@ class SellingController(StockController):
 				coupon_customer = frappe.get_value("Coupon Code", self.coupon_code, "allowed_customer")
 				coupon_customer_group = frappe.get_value("Coupon Code", self.coupon_code, "allowed_customer_group")
 
+				party_name = self.customer_name if self.doctype != "Quotation" else self.party_name
+
 				if self.doctype == "Quotation" and self.quotation_to != "Customer":
 					if coupon_customer or coupon_customer_group:
 						frappe.throw(_("Coupon \"{}\" can only be used with \"Customer\" party types").format(self.coupon_code))
 
-				if coupon_customer and coupon_customer != self.party_name:
+				if coupon_customer and coupon_customer != party_name:
 					frappe.throw(_("Coupon \"{}\" can not be applied to this customer").format(self.coupon_code))
 				elif coupon_customer_group:
-					customer_group = frappe.get_value("Customer", self.party_name, "customer_group")
+					customer_group = frappe.get_value("Customer", party_name, "customer_group")
 					if customer_group != coupon_customer_group:
 						frappe.throw(_("Coupon \"{}\" may only be applied to {} customer groups.").format(self.coupon_code, coupon_customer_group))
 


### PR DESCRIPTION
Fixes issue where payment entry errors out due to coupon_code field is missing from Sales Invoice.

Also, fixes coupon validation on SO and SI where party_name doesn't exist.