### PR TITLE
fix: hide user_defaults  for filters

### DIFF
--- a/erpnext/selling/doctype/customer/customer_list.js
+++ b/erpnext/selling/doctype/customer/customer_list.js
@@ -1,3 +1,4 @@
 frappe.listview_settings['Customer'] = {
 	add_fields: ["customer_name", "territory", "customer_group", "customer_type", "image"],
+	ignore_user_default_filters: true
 };


### PR DESCRIPTION
Depends on [#416](https://github.com/Bloomstack/frappe/pull/416)