### PR TITLE
fix: Don't query missing contact record

### DIFF
--- a/erpnext/shopping_cart/utils.py
+++ b/erpnext/shopping_cart/utils.py
@@ -56,12 +56,9 @@ def update_website_context(context):
 				"customer_name": customer_name
 			})
 
-			if primary_contact:
-				try:
-					contact = frappe.get_doc("Contact", primary_contact)
-					context.update({"session_customer_primary_contact": contact})
-				except Exception as ex:
-					print(ex)
+			if primary_contact and frappe.db.exists("Contact", primary_contact):
+				contact = frappe.get_doc("Contact", primary_contact)
+				context.update({"session_customer_primary_contact": contact})
 					
 def check_customer_or_supplier():
 	if frappe.session.user:


### PR DESCRIPTION
removes try-catch for not fetching a contact record that doesn't exist