### PR TITLE
chore: move batch_no from bloomstack_core to erpnext

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -710,4 +710,5 @@ erpnext.patches.v13_0.update_global_search
 erpnext.patches.v13_0.update_title_field_in_bom
 erpnext.patches.v13_0.update_batch_no_in_purchase_receipt
 erpnext.patches.v13_0.set_package_tag_qty_in_package_tag
+execute:frappe.delete_doc_if_exists("Custom Field", "Sales Order Item-batch_no") 
 

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -68,6 +68,7 @@
   "warehouse",
   "target_warehouse",
   "prevdoc_docname",
+  "batch_no",
   "col_break4",
   "blanket_order",
   "blanket_order_rate",
@@ -771,11 +772,17 @@
    "options": "Package Tag",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "batch_no",
+   "fieldtype": "Link",
+   "label": "COA Batch",
+   "options": "Batch"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-12-17 03:55:21.161080",
+ "modified": "2021-01-13 02:30:06.813229",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Migrating the COA Batch field from a customization in bloomstack core to a field in the sales order item doctype in erpnext