### PR TITLE
fix(Customer): maps mobile_no to primary address for quick form to function

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -531,6 +531,7 @@ def make_address(args, is_primary_address=1):
 		'address_title': args.get('name'),
 		'address_line1': args.get('address_line1'),
 		'address_line2': args.get('address_line2'),
+		'phone': args.get('phone', args.get('mobile_no'), ''),
 		'city': args.get('city'),
 		'state': args.get('state'),
 		'pincode': args.get('pincode'),


### PR DESCRIPTION
Addition:
- Maps Customer mobile_no field to address phone field if present when creating an address from quick form.

Currently system will break if an address is entered because mobile_no isn't set in the newly mandatory phone field in the Address doctype.

Tho, this fixes the quick form issue. Should the phone field in Address be mandatory?