### PR TITLE
fix: removed auto fill from card holder name field

### DIFF
--- a/erpnext/templates/pages/integrations/authorizenet_checkout.html
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.html
@@ -26,7 +26,7 @@
 						</div>
 						<div class="col-md-8 col-sm-6 pl-0 pr-0">
 							<input id="cardholder-name" name="cardholder-name" class="field w-100" placeholder="{{ _('John Doe') }}"
-								value="{{ payment_context.payer_name }}" />
+								value="" />
 						</div>
 					</div>
 

--- a/erpnext/templates/pages/integrations/authorizenet_checkout.html
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.html
@@ -25,8 +25,7 @@
 							<label>{{ _("Card Holder Name") }}</label>
 						</div>
 						<div class="col-md-8 col-sm-6 pl-0 pr-0">
-							<input id="cardholder-name" name="cardholder-name" class="field w-100" placeholder="{{ _('John Doe') }}"
-								value="" />
+							<input id="cardholder-name" name="cardholder-name" class="field w-100" placeholder="{{ _('John Doe') }}" />
 						</div>
 					</div>
 
@@ -35,8 +34,7 @@
 							<label>{{ _("Email") }}</label>
 						</div>
 						<div class="col-md-8 col-sm-6 pl-0 pr-0">
-							<input id="cardholder-email" name="cardholder-email" class="field w-100" placeholder="{{ _('john@doe.com') }}"
-								value="{{ payment_context.payer_email }}" />
+							<input id="cardholder-email" name="cardholder-email" class="field w-100" placeholder="{{ _('john@doe.com') }}" />
 						</div>
 					</div>
 


### PR DESCRIPTION
**Task Link:** https://app.asana.com/0/1192407902292792/1199659885018551/f

**Description:** Before the card holder name is auto fetched, now removed auto-fill from card_holder_name field. Now user can enter their name in that field.

**Screenshot:**

- Before
![Screenshot from 2021-02-02 18-27-24](https://user-images.githubusercontent.com/53329367/106603481-5751d000-6584-11eb-9667-17b9b5edaa16.png)

- After
![image](https://user-images.githubusercontent.com/53329367/106603323-28d3f500-6584-11eb-8b55-635da2f9c4db.png)
