### PR TITLE
fix: resume attach button not visible bug

### DIFF
--- a/erpnext/hr/doctype/job_applicant/job_applicant.js
+++ b/erpnext/hr/doctype/job_applicant/job_applicant.js
@@ -42,7 +42,5 @@ frappe.ui.form.on("Job Applicant", {
 				}
 			};
 		});
-	
-		frm.set_df_property("resume_attachment", "reqd", frm.is_new() ? 0 : 1);
 	}
 });

--- a/erpnext/hr/doctype/job_applicant/job_applicant.json
+++ b/erpnext/hr/doctype/job_applicant/job_applicant.json
@@ -81,10 +81,10 @@
    "label": "Cover Letter"
   },
   {
-   "depends_on": "eval:!doc.__islocal",
    "fieldname": "resume_attachment",
    "fieldtype": "Attach",
-   "label": "Resume Attachment"
+   "label": "Resume Attachment",
+   "reqd": 1
   },
   {
    "fieldname": "first_name",
@@ -101,7 +101,7 @@
  ],
  "icon": "fa fa-user",
  "idx": 1,
- "modified": "2021-01-04 00:01:09.812371",
+ "modified": "2021-02-03 23:48:31.993391",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Applicant",


### PR DESCRIPTION
Resume attachment Bug fixed.
The button is now visible and able to attach and upload resume.

https://user-images.githubusercontent.com/56474017/106869534-0f52ba80-66f6-11eb-9419-075b56df27a5.mp4

.
