### PR TITLE
fix: validating Company on save and adding Project in List API for Expense Claim

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -31,6 +31,7 @@ class ExpenseClaim(AccountsController):
 		self.calculate_total_amount()
 		set_employee_name(self)
 		self.set_expense_account(validate=True)
+		self.set_company()
 		self.set_payable_account()
 		self.set_cost_center()
 		self.calculate_taxes()
@@ -55,6 +56,10 @@ class ExpenseClaim(AccountsController):
 			self.status = "Unpaid"
 		elif self.docstatus == 1 and self.approval_status == 'Rejected':
 			self.status = 'Rejected'
+
+	def set_company(self):
+		if not self.company:
+			self.company = frappe.get_value("Employee", self.employee, "company")
 
 	def set_payable_account(self):
 		if not self.payable_account and not self.is_paid:
@@ -434,7 +439,7 @@ def list_expense_claims(user,filters=None):
 		filters = {"employee": employee}
 
 	expense_claims = frappe.get_all("Expense Claim",filters = filters ,
-		fields=["name", "employee_name", "approval_status","expense_approver", "`tabExpense Claim Detail`.*"])
+		fields=["name", "employee_name", "approval_status", "expense_approver", "project", "`tabExpense Claim Detail`.*"])
 
 	if not expense_claims:
 		return _("No Claim Found for {0}.").format(user)


### PR DESCRIPTION
[TASK](https://app.asana.com/0/1192407897953440/1199922580432652/f)

Expense Claim List API requires "Project" in response as well.
setting Company if not set, it further auto fetch Payable Account for Expense claim