### PR TITLE
fix: Rename bank reconciliation and delete bank reco doctype

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -712,3 +712,4 @@ erpnext.patches.v13_0.update_batch_no_in_purchase_receipt
 erpnext.patches.v13_0.set_package_tag_qty_in_package_tag
 execute:frappe.delete_doc_if_exists("Custom Field", "Sales Order Item-batch_no")
 erpnext.patches.v13_0.delete_package_tag_property_setter_search_fields
+erpnext.patches.v13_0.delete_bank_reconciliation_doctype

--- a/erpnext/patches/v13_0/delete_bank_reconciliation_doctype.py
+++ b/erpnext/patches/v13_0/delete_bank_reconciliation_doctype.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	if frappe.db.table_exists("Bank Reconciliation"):
+		frappe.rename_doc('DocType', 'Bank Reconciliation', 'Bank Clearance', force=True, ignore_if_exists=True)
+		frappe.reload_doc('accounts', 'doctype', 'bank_clearance')
+
+		frappe.rename_doc('DocType', 'Bank Reconciliation Detail', 'Bank Clearance Detail', force=True, ignore_if_exists=True)
+		frappe.reload_doc('accounts', 'doctype', 'bank_clearance_detail')
+
+	frappe.delete_doc_if_exists("DocType", "Bank Reconciliation")
+	frappe.delete_doc_if_exists("DocType", "Bank Reconciliation Detail")


### PR DESCRIPTION
TASK ID: [ASANA](https://app.asana.com/0/1199930991488394/1199879510190163)
If a table exists it will rename and if previous patch its renamed still some doctype remain in the system or not delete doctype. it will delete 