### PR TITLE
fix: fetch manufacturing type from work_order in stock entry

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -695,6 +695,7 @@ def make_stock_entry(work_order_id, purpose, qty=None):
 	stock_entry.company = work_order.company
 	stock_entry.from_bom = 1
 	stock_entry.bom_no = work_order.bom_no
+	stock_entry.manufacturing_type = work_order.manufacturing_type
 	stock_entry.use_multi_level_bom = work_order.use_multi_level_bom
 	stock_entry.fg_completed_qty = qty or (flt(work_order.qty) - flt(work_order.produced_qty))
 	if work_order.bom_no:


### PR DESCRIPTION
Ref : [Asana Task](https://app.asana.com/0/1199082161983365/1199914773945179)

Fixed manufacturing type fetching from work order for Stock Entry.



https://user-images.githubusercontent.com/56474017/108587583-6ef9c880-737a-11eb-98b0-6b05bbc730f5.mp4

 