### PR TITLE
feat: Added purchase receipt field in stock entry doctype

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -645,7 +645,6 @@
    "fieldname": "purchase_receipt",
    "fieldtype": "Read Only",
    "label": "Purchase Receipt",
-  
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -645,7 +645,7 @@
    "fieldname": "purchase_receipt",
    "fieldtype": "Read Only",
    "label": "Purchase Receipt",
-   "read_only": 1
+  
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -14,6 +14,7 @@
   "purpose",
   "company",
   "work_order",
+  "purchase_receipt",
   "purchase_order",
   "delivery_note_no",
   "sales_invoice_no",
@@ -638,12 +639,19 @@
    "label": "Harvest",
    "options": "Harvest",
    "read_only": 1
+  },
+  {
+   "fetch_from": "work_order.purchase_receipt",
+   "fieldname": "purchase_receipt",
+   "fieldtype": "Data",
+   "label": "Purchase Receipt",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 1,
  "is_submittable": 1,
- "modified": "2020-09-10 23:06:16.110675",
+ "modified": "2021-02-23 03:28:53.093340",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -643,7 +643,7 @@
   {
    "fetch_from": "work_order.purchase_receipt",
    "fieldname": "purchase_receipt",
-   "fieldtype": "Data",
+   "fieldtype": "Read Only",
    "label": "Purchase Receipt",
    "read_only": 1
   }
@@ -651,7 +651,7 @@
  "icon": "fa fa-file-text",
  "idx": 1,
  "is_submittable": 1,
- "modified": "2021-02-23 03:28:53.093340",
+ "modified": "2021-02-23 05:40:35.211880",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",


### PR DESCRIPTION
**Task Link:** https://app.asana.com/0/0/1199600812134038/f

**Description:** Added purchase receipt field in stock entry doctype so that we can fetch the stock entry's item table data and display it on purchase invoice print format.

**Screenshot:** 
![image](https://user-images.githubusercontent.com/53329367/108501880-ef1b2200-72d7-11eb-947a-0134a158bb19.png)
