### PR TITLE
fix: filter based on current bank account

### DIFF
--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -308,7 +308,8 @@ erpnext.accounts.ReconciliationTool = class ReconciliationTool extends frappe.vi
 
 		return Object.assign({}, args, {
 			...args.filters.push(["Bank Transaction", "docstatus", "=", 1],
-				["Bank Transaction", "unallocated_amount", ">", 0],["Bank Transaction", "bank_account", "=", this.bank_account])
+				["Bank Transaction", "unallocated_amount", ">", 0],
+				["Bank Transaction", "bank_account", "=", this.bank_account])
 		});
 	}
 

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -65,6 +65,7 @@ erpnext.accounts.bankReconciliation = class BankReconciliation {
 					me.bank_account = null;
 					me.page.hide_actions_menu();
 				}
+				me.clear_page_content();
 			}
 		})
 	}
@@ -114,6 +115,8 @@ erpnext.accounts.bankReconciliation = class BankReconciliation {
 		frappe.model.with_doctype("Bank Transaction", () => {
 			erpnext.accounts.ReconciliationList = new erpnext.accounts.ReconciliationTool({
 				parent: me.parent,
+				bank_account: me.bank_account,
+				company: me.company,
 				doctype: "Bank Transaction"
 			});
 		})
@@ -261,7 +264,6 @@ erpnext.accounts.ReconciliationTool = class ReconciliationTool extends frappe.vi
 		this.page_title = __("Bank Reconciliation");
 		this.doctype = 'Bank Transaction';
 		this.fields = ['date', 'description', 'debit', 'credit', 'currency']
-
 	}
 
 	setup_view() {
@@ -296,10 +298,10 @@ erpnext.accounts.ReconciliationTool = class ReconciliationTool extends frappe.vi
 			page_length: this.page_length,
 			view: this.view
 		};
-
+		console.log("filters", args.filters)
 		return Object.assign({}, args, {
 			...args.filters.push(["Bank Transaction", "docstatus", "=", 1],
-				["Bank Transaction", "unallocated_amount", ">", 0])
+				["Bank Transaction", "unallocated_amount", ">", 0],["Bank Transaction", "bank_account", "=", this.bank_account])
 		});
 	}
 

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -305,7 +305,7 @@ erpnext.accounts.ReconciliationTool = class ReconciliationTool extends frappe.vi
 			page_length: this.page_length,
 			view: this.view
 		};
-		console.log("filters", args.filters)
+
 		return Object.assign({}, args, {
 			...args.filters.push(["Bank Transaction", "docstatus", "=", 1],
 				["Bank Transaction", "unallocated_amount", ">", 0],["Bank Transaction", "bank_account", "=", this.bank_account])

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -59,15 +59,23 @@ erpnext.accounts.bankReconciliation = class BankReconciliation {
 			},
 			onchange: function() {
 				if (this.value) {
+					me.filter_change();
 					me.bank_account = this.value;
 					me.add_actions();
 				} else {
 					me.bank_account = null;
 					me.page.hide_actions_menu();
 				}
-				me.clear_page_content();
 			}
 		})
+	}
+
+	filter_change() {
+		const me = this;
+		$(me.page.body).find('.frappe-list').remove();
+		const empty_state = __("Upload a bank statement, link or reconcile a bank account")
+		me.$main_section.append(`<div class="flex justify-center align-center text-muted"
+			style="height: 50vh; display: flex;"><h5 class="text-muted">${empty_state}</h5></div>`)
 	}
 
 	check_plaid_status() {
@@ -83,7 +91,6 @@ erpnext.accounts.bankReconciliation = class BankReconciliation {
 
 	add_actions() {
 		const me = this;
-
 		me.page.show_menu()
 
 		me.page.add_menu_item(__("Upload a statement"), function() {


### PR DESCRIPTION
TASK ID: [ASANA](https://app.asana.com/0/1199930991488394/1199525872494783)

Changes: 
Before:
Previously when you select the company and bank account filter and when you reconcile it fetch all the transaction irrespective of the filter bank account
![Peek 2021-02-24 13-01](https://user-images.githubusercontent.com/6947417/108963727-7da8ee00-76a0-11eb-996f-ab8fef97cad6.gif)

after:
now, it will fetch filtered reconcile the transaction

![Peek 2021-02-24 12-59](https://user-images.githubusercontent.com/6947417/108963481-26a31900-76a0-11eb-86be-5a92a929c0c8.gif)
