### PR TITLE
fix: assign default validation method if blank before save

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -712,3 +712,4 @@ erpnext.patches.v13_0.update_batch_no_in_purchase_receipt
 erpnext.patches.v13_0.set_package_tag_qty_in_package_tag
 execute:frappe.delete_doc_if_exists("Custom Field", "Sales Order Item-batch_no")
 erpnext.patches.v13_0.delete_package_tag_property_setter_search_fields
+erpnext.patches.v13_0.set_stock_valuation_method

--- a/erpnext/patches/v13_0/set_stock_valuation_method.py
+++ b/erpnext/patches/v13_0/set_stock_valuation_method.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+    stock_settings = frappe.get_doc('Stock Settings')
+    if not (stock_settings.valuation_method):
+        stock_settings.valuation_method = 'FIFO'
+    stock_settings.save()

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -130,6 +130,7 @@ class Item(WebsiteGenerator):
 		self.validate_customer_provided_part()
 		self.update_defaults_from_item_group()
 		self.validate_auto_reorder_enabled_in_stock_settings()
+		self.validate_valuation_method()
 		self.cant_change()
 		self.update_show_in_website()
 
@@ -888,6 +889,10 @@ class Item(WebsiteGenerator):
 			enabled = frappe.db.get_single_value('Stock Settings', 'auto_indent')
 			if not enabled:
 				frappe.msgprint(msg=_("You have to enable auto re-order in Stock Settings to maintain re-order levels."), title=_("Enable Auto Re-Order"), indicator="orange")
+
+	def validate_valuation_method(self):
+			if not self.valuation_method:
+				self.valuation_method = frappe.db.get_single_value("Stock Settings", "valuation_method")
 
 def get_timeline_data(doctype, name):
 	'''returns timeline data based on stock ledger entry'''

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -76,6 +76,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "FIFO",
    "fieldname": "valuation_method",
    "fieldtype": "Select",
    "label": "Default Valuation Method",
@@ -222,7 +223,7 @@
  "icon": "icon-cog",
  "idx": 1,
  "issingle": 1,
- "modified": "2021-01-11 22:18:52.695070",
+ "modified": "2021-03-10 03:54:14.105887",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",


### PR DESCRIPTION
Ref: [Asana Task](https://app.asana.com/0/1199082161983365/1199608531478425)

Default Validation Method Set: Moving Average 
![image](https://user-images.githubusercontent.com/56474017/110117426-d7b35d00-7dde-11eb-94d2-408088dd1fa1.png)





https://user-images.githubusercontent.com/56474017/110122292-72af3580-7de5-11eb-94c6-ffeeb5711722.mp4

