### PR TITLE
fix: added patch to assign default valuation method FIFO in item master

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -713,5 +713,5 @@ erpnext.patches.v13_0.set_package_tag_qty_in_package_tag
 execute:frappe.delete_doc_if_exists("Custom Field", "Sales Order Item-batch_no")
 erpnext.patches.v13_0.delete_package_tag_property_setter_search_fields
 erpnext.patches.v13_0.set_batch_qty_in_batch
-erpnext.patches.v13_0.set_stock_valuation_method
+erpnext.patches.v13_0.set_stock_valuation_method #2021-03-15
 erpnext.patches.v13_0.delete_bank_reconciliation_doctype

--- a/erpnext/patches/v13_0/set_stock_valuation_method.py
+++ b/erpnext/patches/v13_0/set_stock_valuation_method.py
@@ -5,3 +5,12 @@ def execute():
     if not (stock_settings.valuation_method):
         stock_settings.valuation_method = 'FIFO'
     stock_settings.save()
+
+    #Updating valuation method for exisitng items
+    frappe.reload_doc("stock", "doctype", "item")
+    frappe.db.sql("""
+        UPDATE `tabItem`
+        SET
+            valuation_method = 'FIFO'
+        WHERE valuation_method = ''
+	""")


### PR DESCRIPTION
Ref: [Asana Task](https://app.asana.com/0/1199082161983365/1199608531478425)

Patch added to update the valuation method for existing/older items in item master.