### PR TITLE
feat: Link Sticker Items to the Batch they're created for in Material Request

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -45,6 +45,13 @@
   "pricing_rules",
   "item_ignore_pricing_rule",
   "is_free_item",
+  "section_break_label",
+  "coa_batch",
+  "jar_type",
+  "labels_needed",
+  "unwind_direction",
+  "column_break_label",
+  "label_details",
   "section_break_22",
   "net_rate",
   "net_amount",
@@ -784,11 +791,47 @@
    "fieldtype": "Link",
    "label": "Package Tag",
    "options": "Package Tag"
+  },
+  {
+   "fieldname": "section_break_label",
+   "fieldtype": "Section Break",
+   "label": "Label Details"
+  },
+  {
+   "fieldname": "coa_batch",
+   "fieldtype": "Link",
+   "label": "COA Batch",
+   "options": "Batch"
+  },
+  {
+   "fieldname": "jar_type",
+   "fieldtype": "Data",
+   "label": "Jar Type (Flower Only)"
+  },
+  {
+   "fieldname": "labels_needed",
+   "fieldtype": "Data",
+   "label": "Labels Needed (Wrap, Front, Back, Top, Bag, etc.)"
+  },
+  {
+   "fieldname": "unwind_direction",
+   "fieldtype": "Data",
+   "label": "Unwind Direction (Flower Only)"
+  },
+  {
+   "fieldname": "column_break_label",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "label_details",
+   "fieldtype": "Long Text",
+   "label": "Label Print Details",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2021-01-14 00:33:59.858285",
+ "modified": "2021-03-15 08:18:07.349463",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -45,6 +45,13 @@
   "item_ignore_pricing_rule",
   "is_free_item",
   "is_fixed_asset",
+  "section_break_label",
+  "coa_batch",
+  "jar_type",
+  "labels_needed",
+  "unwind_direction",
+  "column_break_label",
+  "label_details",
   "section_break_29",
   "net_rate",
   "net_amount",
@@ -740,11 +747,47 @@
    "fieldname": "material_request_plan_item",
    "fieldtype": "Data",
    "label": "Material Request Plan Item"
+  },
+  {
+   "fieldname": "section_break_label",
+   "fieldtype": "Section Break",
+   "label": "Label Details"
+  },
+  {
+   "fieldname": "coa_batch",
+   "fieldtype": "Link",
+   "label": "COA Batch",
+   "options": "Batch"
+  },
+  {
+   "fieldname": "jar_type",
+   "fieldtype": "Data",
+   "label": "Jar Type (Flower Only)"
+  },
+  {
+   "fieldname": "labels_needed",
+   "fieldtype": "Data",
+   "label": "Labels Needed (Wrap, Front, Back, Top, Bag, etc.)"
+  },
+  {
+   "fieldname": "unwind_direction",
+   "fieldtype": "Data",
+   "label": "Unwind Direction (Flower Only)"
+  },
+  {
+   "fieldname": "column_break_label",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "label_details",
+   "fieldtype": "Long Text",
+   "label": "Label Print Details",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-12-09 03:10:41.856034",
+ "modified": "2021-03-15 07:46:17.788951",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -123,6 +123,26 @@ erpnext.utils.add_item = function(frm) {
 	}
 }
 
+erpnext.utils.add_coa_batch = function(frm) {
+	if(frm.is_new()) {
+		var prev_route = frappe.get_prev_route();
+		if(prev_route[1]==='Batch' && !(frm.doc.items && frm.doc.items.length)) {
+			// add row
+			var item = frm.add_child('items');
+			frm.refresh_field('items');
+
+			// set coa batch and label details
+			frappe.model.set_value(item.doctype, item.name, 'coa_batch', prev_route[2]);
+			if (item.coa_batch) {
+				frappe.db.get_value("Batch", { "name": item.coa_batch }, ["label_details"], (r) => {
+					frappe.model.set_value(item.doctype, item.name, "label_details", r.label_details);
+					refresh_field("items");
+				})
+			}
+		}
+	}
+}
+
 erpnext.utils.get_address_display = function(frm, address_field, display_field, is_your_company_address) {
 	if(frm.updating_party_details) return;
 

--- a/erpnext/stock/doctype/batch/batch.js
+++ b/erpnext/stock/doctype/batch/batch.js
@@ -17,6 +17,10 @@ frappe.ui.form.on('Batch', {
 				method: "erpnext.selling.doctype.sales_order.sales_order.make_sales_order_from_batch",
 				frm: frm
 			}),
+			'Material Request': () => frappe.model.open_mapped_doc({
+				method: "erpnext.stock.doctype.material_request.material_request.make_material_request",
+				frm: frm
+			})
 		}
 	},
 	refresh: (frm) => {
@@ -31,12 +35,21 @@ frappe.ui.form.on('Batch', {
 			frm.add_custom_button(__('Material Request'), () => {
 				frm.trigger("make_material_request");
 			}, __("Create"));
+			frm.add_custom_button(__('Material Request (COA Batch)'), () => {
+				frm.trigger("make_coa_material_request");
+			}, __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
 	},
 	make_material_request: function (frm) {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.stock.doctype.material_request.material_request.make_material_request",
+			frm: frm
+		});
+	},
+	make_coa_material_request: function (frm) {
+		frappe.model.open_mapped_doc({
+			method: "erpnext.stock.doctype.batch.batch.create_coa_material_request",
 			frm: frm
 		});
 	},

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -424,3 +424,19 @@ def get_active_batch(item_code):
 	else:
 		active_batch = {}
 	return active_batch
+
+@frappe.whitelist()
+def create_coa_material_request(source_name, target_doc=None):
+	"""
+	Creating Material Request from Batch.
+
+	Args:
+		source_name (string): batch name
+		target_doc (json, optional): json of new material_request doc. Defaults to None.
+
+	Returns:
+		target_doc (json): new material_request doc
+	"""
+	doc = frappe.get_doc("Batch", source_name)
+	target_doc = frappe.new_doc("Material Request")
+	return target_doc

--- a/erpnext/stock/doctype/batch/batch_dashboard.py
+++ b/erpnext/stock/doctype/batch/batch_dashboard.py
@@ -9,7 +9,7 @@ def get_data():
 		'transactions': [
 			{
 				'label': _('Buy'),
-				'items': ['Purchase Invoice', 'Purchase Receipt']
+				'items': ['Material Request', 'Purchase Invoice', 'Purchase Receipt']
 			},
 			{
 				'label': _('Sell'),

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -30,6 +30,9 @@ frappe.ui.form.on('Material Request', {
 		// add item, if previous view was item
 		erpnext.utils.add_item(frm);
 
+		//add coa batch and label details, if previous view was batch
+		erpnext.utils.add_coa_batch(frm);
+
 		// set schedule_date
 		set_schedule_date(frm);
 	},

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -37,7 +37,7 @@
   "amount",
   "stock_qty",
   "section_break_label",
-  "label_qty",
+  "coa_batch",
   "jar_type",
   "labels_needed",
   "unwind_direction",
@@ -448,11 +448,6 @@
    "label": "Unwind Direction (Flower Only)"
   },
   {
-   "fieldname": "label_qty",
-   "fieldtype": "Int",
-   "label": "Label Quantity"
-  },
-  {
    "fieldname": "batch_item",
    "fieldtype": "Link",
    "label": "Batch Item",
@@ -500,11 +495,17 @@
    "fieldtype": "Link",
    "label": "Source Warehouse (Material Transfer)",
    "options": "Warehouse"
+  },
+  {
+   "fieldname": "coa_batch",
+   "fieldtype": "Link",
+   "label": "COA Batch",
+   "options": "Batch"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2021-02-18 22:05:35.766070",
+ "modified": "2021-03-15 07:22:45.831726",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -51,6 +51,13 @@
   "pricing_rules",
   "item_ignore_pricing_rule",
   "is_free_item",
+  "section_break_label",
+  "coa_batch",
+  "jar_type",
+  "labels_needed",
+  "unwind_direction",
+  "column_break_label",
+  "label_details",
   "section_break_29",
   "net_rate",
   "net_amount",
@@ -858,11 +865,47 @@
    "fieldname": "material_request_plan_item",
    "fieldtype": "Data",
    "label": "Material Request Plan Item"
+  },
+  {
+   "fieldname": "section_break_label",
+   "fieldtype": "Section Break",
+   "label": "Label Details"
+  },
+  {
+   "fieldname": "coa_batch",
+   "fieldtype": "Link",
+   "label": "COA Batch",
+   "options": "Batch"
+  },
+  {
+   "fieldname": "jar_type",
+   "fieldtype": "Data",
+   "label": "Jar Type (Flower Only)"
+  },
+  {
+   "fieldname": "labels_needed",
+   "fieldtype": "Data",
+   "label": "Labels Needed (Wrap, Front, Back, Top, Bag, etc.)"
+  },
+  {
+   "fieldname": "unwind_direction",
+   "fieldtype": "Data",
+   "label": "Unwind Direction (Flower Only)"
+  },
+  {
+   "fieldname": "column_break_label",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "label_details",
+   "fieldtype": "Long Text",
+   "label": "Label Print Details",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2021-01-14 03:11:56.000436",
+ "modified": "2021-03-15 08:01:26.374719",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
TASK ID: [ASANA](https://app.asana.com/0/1192407894480744/1200009803660563)
Changes:
1. Added Material Request in Dashboard
2.  Added Create Material Request (coa batch) button to create a material request for coa bath
3.  carry forward coa batch and label details from material request to subsequent document like purchase order, purchase receipt, and purchase invoice

GIf for reference:
![Peek 2021-03-16 13-22](https://user-images.githubusercontent.com/6947417/111274263-ce39b880-865a-11eb-971f-056e2f891541.gif)
