### PR TITLE
fix: remove vendor key from settings

### DIFF
--- a/erpnext/compliance/doctype/compliance_settings/compliance_settings.json
+++ b/erpnext/compliance/doctype/compliance_settings/compliance_settings.json
@@ -9,7 +9,6 @@
   "sb_metrc_settings",
   "metrc_url",
   "cb_metrc",
-  "metrc_vendor_key",
   "metrc_user_key",
   "section_break_9",
   "company"
@@ -42,16 +41,10 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "metrc_vendor_key",
-   "fieldtype": "Password",
-   "in_list_view": 1,
-   "label": "Vendor Key"
-  },
-  {
    "fieldname": "metrc_user_key",
    "fieldtype": "Password",
    "in_list_view": 1,
-   "label": "User Key"
+   "label": "User Key / API Key"
   },
   {
    "fieldname": "section_break_9",
@@ -66,7 +59,7 @@
   }
  ],
  "issingle": 1,
- "modified": "2020-11-26 04:55:47.274738",
+ "modified": "2021-03-17 05:25:50.288090",
  "modified_by": "Administrator",
  "module": "Compliance",
  "name": "Compliance Settings",


### PR DESCRIPTION
- Removing the user vendor key since it is not for reporting to METRC.
- We use our own keys to do