### PR TITLE
feat: Added feature to get sub-assembly item with exploded item in production plan for material request

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -35,6 +35,7 @@
   "for_warehouse",
   "download_materials_required",
   "get_items_for_mr",
+  "include_sub_assembly_with_exploded_item",
   "section_break_27",
   "mr_items",
   "other_details",
@@ -296,11 +297,17 @@
    "fieldname": "per_received",
    "fieldtype": "Percent",
    "label": "% Received"
+  },
+  {
+   "default": "0",
+   "fieldname": "include_sub_assembly_with_exploded_item",
+   "fieldtype": "Check",
+   "label": "Get Sub Assembly Item with Exploded item"
   }
  ],
  "icon": "fa fa-calendar",
  "is_submittable": 1,
- "modified": "2021-01-18 23:51:52.293811",
+ "modified": "2021-04-06 22:03:47.960915",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -483,6 +483,49 @@ def get_exploded_items(item_details, company, bom_no, include_non_stock_items, p
 			item_details.setdefault(d.get('item_code'), d)
 	return item_details
 
+def get_exploded_items_with_subassembly(item_details, company, bom_no, include_non_stock_items, planned_qty=1):
+	explosion_items = frappe.db.sql("""select bei.item_code, item.default_bom as bom,
+			ifnull(sum(bei.stock_qty/ifnull(bom.quantity, 1)), 0)*%s as qty, item.item_name,
+			bei.description, bei.stock_uom, item.min_order_qty, bei.source_warehouse,
+			item.default_material_request_type, item.min_order_qty, item_default.default_warehouse,
+			item.purchase_uom, item_uom.conversion_factor
+		from
+			`tabBOM Explosion Item` bei
+			JOIN `tabBOM` bom ON bom.name = bei.parent
+			JOIN `tabItem` item ON item.name = bei.item_code
+			LEFT JOIN `tabItem Default` item_default
+				ON item_default.parent = item.name and item_default.company=%s
+			LEFT JOIN `tabUOM Conversion Detail` item_uom
+				ON item.name = item_uom.parent and item_uom.uom = item.purchase_uom
+		where
+			bei.docstatus < 2
+			and bom.name=%s and item.is_stock_item in (1, {0})
+		group by bei.item_code, bei.stock_uom""".format(0 if include_non_stock_items else 1),
+		(planned_qty, company, bom_no), as_dict=1)
+
+	bom_items = frappe.db.sql("""select bei.item_code, item.default_bom as bom,
+			ifnull(sum(bei.stock_qty/ifnull(bom.quantity, 1)), 0)*%s as qty, item.item_name,
+			bei.description, bei.stock_uom, item.min_order_qty, bei.source_warehouse,
+			item.default_material_request_type, item.min_order_qty, item_default.default_warehouse,
+			item.purchase_uom, item_uom.conversion_factor
+		from
+			`tabBOM Item` bei
+			JOIN `tabBOM` bom ON bom.name = bei.parent
+			JOIN `tabItem` item ON item.name = bei.item_code
+			LEFT JOIN `tabItem Default` item_default
+				ON item_default.parent = item.name and item_default.company=%s
+			LEFT JOIN `tabUOM Conversion Detail` item_uom
+				ON item.name = item_uom.parent and item_uom.uom = item.purchase_uom
+		where
+			bei.docstatus < 2
+			and bom.name=%s and item.is_stock_item in (1, {0})
+		group by bei.item_code, bei.stock_uom""".format(0 if include_non_stock_items else 1),
+		(planned_qty, company, bom_no), as_dict=1)
+
+	for d in explosion_items + bom_items:
+		item_details.setdefault(d.get('item_code'), d)
+	return item_details
+
 def get_subitems(doc, data, item_details, bom_no, company, include_non_stock_items,
 	include_subcontracted_items, parent_qty, planned_qty=1):
 	items = frappe.db.sql("""
@@ -665,9 +708,13 @@ def get_items_for_material_requests(doc, ignore_existing_ordered_qty=None):
 				frappe.throw(_("For row {0}: Enter Planned Qty").format(data.get('idx')))
 
 			if bom_no:
-				if data.get('include_exploded_items') and include_subcontracted_items:
+				if data.get('include_exploded_items') and include_subcontracted_items and not doc.get("include_sub_assembly_with_exploded_item"):
 					# fetch exploded items from BOM
 					item_details = get_exploded_items(item_details,
+						company, bom_no, include_non_stock_items, planned_qty=planned_qty)
+				elif  data.get('include_exploded_items') and include_subcontracted_items and doc.get("include_sub_assembly_with_exploded_item"): 
+					# fetch exploded items with sub assembly item from BOM
+					item_details = get_exploded_items_with_subassembly(item_details,
 						company, bom_no, include_non_stock_items, planned_qty=planned_qty)
 				else:
 					item_details = get_subitems(doc, data, item_details, bom_no, company,

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -484,14 +484,14 @@ def get_exploded_items(item_details, company, bom_no, include_non_stock_items, p
 	return item_details
 
 def get_exploded_items_with_subassembly(item_details, company, bom_no, include_non_stock_items, planned_qty=1):
-	explosion_items = get_items_for_explod_and_subassembly("BOM Explosion Item", company, bom_no, include_non_stock_items, planned_qty)
-	bom_items = get_items_for_explod_and_subassembly("BOM Item", company, bom_no, include_non_stock_items, planned_qty)
+	explosion_items = get_items_for_explode_and_subassembly("BOM Explosion Item", company, bom_no, include_non_stock_items, planned_qty)
+	bom_items = get_items_for_explode_and_subassembly("BOM Item", company, bom_no, include_non_stock_items, planned_qty)
 
 	for d in explosion_items + bom_items:
 		item_details.setdefault(d.get('item_code'), d)
 	return item_details
 
-def get_items_for_explod_and_subassembly(item, company, bom_no, include_non_stock_items, planned_qty=1):
+def get_items_for_explode_and_subassembly(item, company, bom_no, include_non_stock_items, planned_qty=1):
 	items = frappe.db.sql("""select bei.item_code, item.default_bom as bom,
 			ifnull(sum(bei.stock_qty/ifnull(bom.quantity, 1)), 0)*%s as qty, item.item_name,
 			bei.description, bei.stock_uom, item.min_order_qty, bei.source_warehouse,


### PR DESCRIPTION
TASK ID: [ASANA](https://app.asana.com/0/1192407894480744/1199630315469131)

CHANGE LOG:
1. Added Get Sub Assembly Item with Exploded item checkbox
2. If the exploded item child table and Get Sub Assembly Item with Exploded item is checked then it will fetch exploded item with subassembly item for material request

![Peek 2021-04-07 11-37](https://user-images.githubusercontent.com/6947417/113818619-ac34e100-9795-11eb-9961-3c46986933e1.gif)
