### PR TITLE
fix: added precision as 6 for rate and amount while doing reverse caluclation

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -336,13 +336,15 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 							fieldtype: 'Float',
 							fieldname: 'rate',
 							read_only: 1,
-							in_list_view: 1
+							in_list_view: 1,
+							precision: 6
 						},
 						{
 							label: __("Amount"),
 							fieldtype: 'Float',
 							fieldname: 'amount',
-							in_list_view: 1
+							in_list_view: 1,
+							precision: 6
 						}
 					],
 				}


### PR DESCRIPTION
Ref: [Asana](https://app.asana.com/0/1192407896547052/1200082397806571)
[github.com/Bloomstack/bloomstack_core](https://github.com/Bloomstack/bloomstack_core/pull/583)