### PR TITLE
fix: Pick List Applied Filters for unused package tag and updating package tag on submit/cancel of Purchase Receipt

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -55,7 +55,8 @@ frappe.ui.form.on('Pick List', {
 			const row = frm.selected_doc || locals[cdt][cdn];
 			return {
 				filters: {
-					"item_code": ["IN", [row.item_code, ""]]
+					"item_code": ["IN", [row.item_code, ""]],
+					"is_used" : 0
 				}
 			};
 		});

--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -55,7 +55,6 @@ frappe.ui.form.on('Pick List', {
 			const row = frm.selected_doc || locals[cdt][cdn];
 			return {
 				filters: {
-					"item_code": ["IN", [row.item_code, ""]],
 					"is_used" : 0
 				}
 			};

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -488,13 +488,15 @@ class PurchaseReceipt(BuyingController):
 					"item_name": None,
 					"item_group": None,
 					"batch_no": None,
-					"coa_batch_no": None
+					"coa_batch_no": None,
+					"is_used" : 0
 				})
 			else:
 				package_tag.update({
 					"item_code": item.item_code,
 					"item_name": item.item_name,
-					"item_group": frappe.db.get_value("Item", item.item_code, "item_group")
+					"item_group": frappe.db.get_value("Item", item.item_code, "item_group"),
+					"is_used" : 1
 				})
 				if item.batch_no:
 					package_tag.update({


### PR DESCRIPTION
Purchase Receipt:
[TASK1](https://app.asana.com/0/1192407897953440/1200116476785917/f)


![PR_update_Packagetag_isused](https://user-images.githubusercontent.com/58166671/114701273-38b84400-9d40-11eb-954d-47d056ee7d8d.gif)

Pick List:
[TASK2](https://app.asana.com/0/1192407897953440/1200116476785918/f)

![picklist_packagetag_filter](https://user-images.githubusercontent.com/58166671/114700925-ca738180-9d3f-11eb-88d8-aae99df520d7.gif)
