### PR TITLE
Chore: Hide the Customer Primary Contact Section

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1605,6 +1605,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	tax_category: function() {
 		var me = this;
+		if(!me.frm.doc.tax_category) return;
 		if(me.frm.updating_party_details) return;
 
 		frappe.run_serially([

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -119,9 +119,9 @@
    "depends_on": "eval:doc.customer_type != 'Company'",
    "fieldname": "gender",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Gender",
-   "options": "Gender",
-   "hidden": 1
+   "options": "Gender"
   },
   {
    "default": "Company",
@@ -299,6 +299,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:!doc.__islocal",
    "description": "Select, to make the customer searchable with these fields",
    "fieldname": "primary_address_and_contact_detail",
    "fieldtype": "Section Break",
@@ -556,7 +557,7 @@
  "icon": "fa fa-user",
  "idx": 363,
  "image_field": "image",
- "modified": "2021-01-14 00:01:18.784725",
+ "modified": "2021-04-19 22:43:18.580824",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
![Cust1](https://user-images.githubusercontent.com/80836439/115366103-a05c0c80-a1e2-11eb-9c89-e1b279721801.PNG)
![cust2](https://user-images.githubusercontent.com/80836439/115366111-a225d000-a1e2-11eb-8caa-8e646b567104.PNG)
![Cust3](https://user-images.githubusercontent.com/80836439/115366115-a2be6680-a1e2-11eb-9a76-3ac2e809c765.PNG)

Hide the filed Customer Primary Contact, where on creation on a new customer, the table is linked to "New Customer No" and not linked to the customer being created.