### PR TITLE
fix: change batch field in SLE to link field

### DIFF
--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -1,6 +1,6 @@
 {
  "allow_import": 1,
- "autoname": "field:batch_id",
+ "allow_rename": 1,
  "creation": "2013-03-05 14:50:38",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -226,7 +226,7 @@
  "idx": 1,
  "image_field": "image",
  "max_attachments": 5,
- "modified": "2021-03-18 00:20:52.920465",
+ "modified": "2021-04-27 00:38:04.673130",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",
@@ -319,6 +319,5 @@
  "quick_entry": 1,
  "search_fields": "item,item_name,batch_qty,stock_uom",
  "sort_field": "modified",
- "sort_order": "DESC",
- "title_field": "batch_id"
+ "sort_order": "DESC"
 }

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -59,11 +59,12 @@
   },
   {
    "fieldname": "batch_no",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Batch No",
    "oldfieldname": "batch_no",
    "oldfieldtype": "Data",
+   "options": "Batch",
    "read_only": 1
   },
   {
@@ -289,7 +290,7 @@
  "icon": "fa fa-list",
  "idx": 1,
  "in_create": 1,
- "modified": "2020-10-23 05:42:52.164730",
+ "modified": "2021-04-27 00:45:23.882197",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",


### PR DESCRIPTION
- [Asana](https://app.asana.com/0/1192118403864545/1199879418974369)
- Batch No in Stock Ledger Entry is a Data Field.
- For renaming a document, the framework fetches all the linked documents based on the meta.
- For Stock Ledger Entry, the Batch No was saved in a data field, due to which it was not able to renaming it.
- Changing the fieldtype of Batch in Stock Ledger Entry, will make sure that the batch is renamed.