### PR TITLE
Fix: Added a check for creation of material request in production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -116,34 +116,19 @@ frappe.ui.form.on('Production Plan', {
 	},
 
 	make_material_request: function(frm) {
-
-		frappe.confirm(__("Do you want to submit the material request"),
-			function() {
-				frm.events.create_material_request(frm, 1);
-			},
-			function() {
-				frm.events.create_material_request(frm, 0);
-			}
-		);
+		frm.events.create_material_request(frm, 1);
 	},
 
 	create_material_request: function(frm, submit) {
 		frm.doc.submit_material_request = submit;
-		if(submit==1)
-		{
-			frappe.call({
-				method: "make_material_request",
-				freeze: true,
-				doc: frm.doc,
-				callback: function(r) {
-					frm.reload_doc();
-				}
-			});
-		}
-		else
-		{
-			frappe.msgprint("No material request created")
-		}
+		frappe.call({
+			method: "make_material_request",
+			freeze: true,
+			doc: frm.doc,
+			callback: function(r) {
+				frm.reload_doc();
+			}
+		});
 	},
 
 	get_sales_orders: function(frm) {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -48,7 +48,7 @@ frappe.ui.form.on('Production Plan', {
 			}, __('Create'));
 		}
 
-		if (frm.doc.docstatus === 1 && frm.doc.mr_items
+		if (frm.doc.docstatus === 1 && frm.doc.mr_items.length>0
 			&& !in_list(['Material Requested', 'Completed'], frm.doc.status)) {
 			frm.add_custom_button(__("Material Request"), ()=> {
 				frm.trigger("make_material_request");
@@ -129,15 +129,21 @@ frappe.ui.form.on('Production Plan', {
 
 	create_material_request: function(frm, submit) {
 		frm.doc.submit_material_request = submit;
-
-		frappe.call({
-			method: "make_material_request",
-			freeze: true,
-			doc: frm.doc,
-			callback: function(r) {
-				frm.reload_doc();
-			}
-		});
+		if(submit==1)
+		{
+			frappe.call({
+				method: "make_material_request",
+				freeze: true,
+				doc: frm.doc,
+				callback: function(r) {
+					frm.reload_doc();
+				}
+			});
+		}
+		else
+		{
+			frappe.msgprint("No material request created")
+		}
 	},
 
 	get_sales_orders: function(frm) {


### PR DESCRIPTION
1. Once the production plan is created and if Material Request Plan Item is not present i.e not selected Get Raw Material for Production. Then it should not be able to see an option of create material request once we submit the production plan and click on create button.
2. Below is the attached img and gif for the same. 
3. ![MR_without_get_raw_material](https://user-images.githubusercontent.com/80836439/117067992-5594d580-ad48-11eb-860a-1a698228290a.PNG)
4. Uploading MR_saving_skeptical_without_Get_raw_material.mp4



Fix : for not  selecting Get Raw Material for Production, once we submit the production plan and click on create button. The material request option is made hidden i.e unless mr_list[0] not present (data) -> grade out the option to create material request.
Below is the fix attached img for the same. 
![MR_fix_without_get_raw_material](https://user-images.githubusercontent.com/80836439/117068412-e10e6680-ad48-11eb-89e0-2c1181a49178.PNG)


1. Once the production plan is created and if Material Request Plan Item is present i.e selected Get Raw Material for Production. Then it should be able to see an option of create material request once we submit the production plan and click on create button.
2. Also if we click outside the prompt button once it asks to confirm whether we need to create a material request or not . Depending upon the options it should create material request 
YES -  should create material req.
NO- should notcreate material req.
Clicked outside the prompt -  should not  create material req.
3. Below is the attached img and gif for the same. 
4. ![MR_with_get_raw_material](https://user-images.githubusercontent.com/80836439/117068979-8e817a00-ad49-11eb-9a06-82eb992e16e7.PNG)
5. https://user-images.githubusercontent.com/80836439/117068984-8fb2a700-ad49-11eb-800a-fb16360e9c71.mp4

Fix : on selecting Get Raw Material for Production, once we submit the production plan and click on create button and confirms yes to create material request , then and only it should create it else prompt a message "No material request created"
Below is the fix attached img and gif for the same. 
![MR_fix_get_raw_materials](https://user-images.githubusercontent.com/80836439/117069211-dc967d80-ad49-11eb-9040-1bd31bd5e59d.PNG)

https://user-images.githubusercontent.com/80836439/117069222-ddc7aa80-ad49-11eb-8ffa-fc0d7a23a16d.mp4


