### PR TITLE
Chore: Added a check to start job and logs it time once job card is saved

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -22,7 +22,7 @@ class JobCard(Document):
 		if self.get('time_logs'):
 			for d in self.get('time_logs'):
 				if d.from_time and d.to_time and get_datetime(d.from_time) > get_datetime(d.to_time):
-						frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
+					frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
 
 				if not frappe.db.get_single_value("Projects Settings", "ignore_workstation_time_overlap"):
 					data = self.get_overlap_for(d)

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -21,8 +21,9 @@ class JobCard(Document):
 
 		if self.get('time_logs'):
 			for d in self.get('time_logs'):
-				if get_datetime(d.from_time) > get_datetime(d.to_time):
-					frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
+				if d.from_time and d.to_time: 
+					if get_datetime(d.from_time) > get_datetime(d.to_time):
+						frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
 
 				if not frappe.db.get_single_value("Projects Settings", "ignore_workstation_time_overlap"):
 					data = self.get_overlap_for(d)

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -21,8 +21,7 @@ class JobCard(Document):
 
 		if self.get('time_logs'):
 			for d in self.get('time_logs'):
-				if d.from_time and d.to_time: 
-					if get_datetime(d.from_time) > get_datetime(d.to_time):
+				if d.from_time and d.to_time and get_datetime(d.from_time) > get_datetime(d.to_time):
 						frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
 
 				if not frappe.db.get_single_value("Projects Settings", "ignore_workstation_time_overlap"):


### PR DESCRIPTION
Since the issue is unable to replicate locally, just added a check to run the if loop, only when both values "from time" and "to time" are available.
Because current logic was incorrect to throw frappe msg "Row 1: From time must be less than to time"
since 2< None = always true  (None = 0 )