### PR TITLE
chore: remove message for xcall

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1488,11 +1488,11 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		const r = await frappe.xcall("erpnext.stock.get_item_details.apply_price_list", {args: args});
 		if (!r.exc) {
 			await frappe.run_serially([
-				() => me.frm.set_value("price_list_currency", r.message.parent.price_list_currency),
-				() => me.frm.set_value("plc_conversion_rate", r.message.parent.plc_conversion_rate),
+				() => me.frm.set_value("price_list_currency", r.parent.price_list_currency),
+				() => me.frm.set_value("plc_conversion_rate", r.parent.plc_conversion_rate),
 				() => {
 					if(args.items.length) {
-						return me._set_values_for_item_list(r.message.children);
+						return me._set_values_for_item_list(r.children);
 					}
 				}
 			]);


### PR DESCRIPTION
- Since frappe.call was removed for frappe.xcall, frappe.xcall does not return message in the response.