### PR TITLE
Hotfix bb old editor

### DIFF
--- a/erpnext/accounts/doctype/coupon_code/coupon_code.js
+++ b/erpnext/accounts/doctype/coupon_code/coupon_code.js
@@ -1,10 +1,6 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 frappe.ui.form.on('Coupon Code', {
-	setup: function(frm) {
-		const $container = $(frm.page.current_view).find('[data-fieldname=brackets_widget]');
-		$container.data("brackets_widget", new erpnext.bloombrackets.Component($container, frm, "brackets_code"));
-	},
 	coupon_name:function(frm){
 		if (frm.doc.__islocal===1) {
 			frm.trigger("make_coupon_code");
@@ -30,6 +26,7 @@ frappe.ui.form.on('Coupon Code', {
 	},
 	refresh: function(frm) {
 		const $container = $(frm.page.current_view).find('[data-fieldname=brackets_widget]');
+		$container.data("brackets_widget", new erpnext.bloombrackets.Component($container, frm, "brackets_code"));
 	}
 });
 

--- a/erpnext/public/js/utils/bloombrackets/renderers/input.js
+++ b/erpnext/public/js/utils/bloombrackets/renderers/input.js
@@ -39,6 +39,7 @@ export const Input = Component("bb-control", (ui, $container, {
         parent: $container,
         horizontal: true
       });
+      link_input.make_wrapper();
       link_input.make_input();
       link_input.toggle_description(false);
       $input = link_input.$input;

--- a/erpnext/public/js/utils/bloombrackets_widget.js
+++ b/erpnext/public/js/utils/bloombrackets_widget.js
@@ -84,7 +84,7 @@ class BloomBracketsComponent {
   }
 
   list_vars() {
-    return Object.keys(this.context['#VARMETA']);
+    return Object.keys(this.context['#VARMETA'] || {});
   }
 }
 

--- a/erpnext/public/scss/bloombrackets.scss
+++ b/erpnext/public/scss/bloombrackets.scss
@@ -22,6 +22,14 @@ $bb-control-focused-outline-color: black;
     padding: 0;
   }
 
+  .frappe-control .form-group .clearfix label {
+    display: none;
+  }
+
+  .frappe-control .form-group .help-box {
+    display: none;
+  }
+
   &.bb-block-top {
     padding-left: 0;
   }

--- a/erpnext/selling/doctype/quotation/quotation_dashboard.py
+++ b/erpnext/selling/doctype/quotation/quotation_dashboard.py
@@ -6,6 +6,8 @@ def get_data():
 		'fieldname': 'prevdoc_docname',
 		'non_standard_fieldnames': {
 			'Auto Repeat': 'reference_document',
+			'Payment Entry': 'reference_name',
+			'Payment Request': 'reference_name'
 		},
 		'transactions': [
 			{
@@ -15,6 +17,10 @@ def get_data():
 			{
 				'label': _('Subscription'),
 				'items': ['Auto Repeat']
+			},
+			{
+				'label': _('Payment'),
+				'items': ['Payment Entry', 'Payment Request']
 			},
 		]
 	}

--- a/erpnext/selling/doctype/quotation/quotation_dashboard.py
+++ b/erpnext/selling/doctype/quotation/quotation_dashboard.py
@@ -6,8 +6,6 @@ def get_data():
 		'fieldname': 'prevdoc_docname',
 		'non_standard_fieldnames': {
 			'Auto Repeat': 'reference_document',
-			'Payment Entry': 'reference_name',
-			'Payment Request': 'reference_name'
 		},
 		'transactions': [
 			{
@@ -17,10 +15,6 @@ def get_data():
 			{
 				'label': _('Subscription'),
 				'items': ['Auto Repeat']
-			},
-			{
-				'label': _('Payment'),
-				'items': ['Payment Entry', 'Payment Request']
 			},
 		]
 	}


### PR DESCRIPTION
Changes:

Moves editor rendering to refresh as HTML field isn't cleaned up between page renders.
Fixed issue where input control wasn't creating internal wrapper causing silent field missing errors.