### PR TITLE
hotfix: Captures promise error into console log so we can track it on sentry

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1485,17 +1485,21 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			return Promise.resolve();
 		}
 
-		const r = await frappe.xcall("erpnext.stock.get_item_details.apply_price_list", {args: args});
-		if (!r.exc) {
-			await frappe.run_serially([
-				() => me.frm.set_value("price_list_currency", r.parent.price_list_currency),
-				() => me.frm.set_value("plc_conversion_rate", r.parent.plc_conversion_rate),
-				() => {
-					if(args.items.length) {
-						return me._set_values_for_item_list(r.children);
+		try {
+			const r = await frappe.xcall("erpnext.stock.get_item_details.apply_price_list", {args: args});
+			if (!r.exc) {
+				await frappe.run_serially([
+					() => me.frm.set_value("price_list_currency", r.parent.price_list_currency),
+					() => me.frm.set_value("plc_conversion_rate", r.parent.plc_conversion_rate),
+					() => {
+						if(args.items.length) {
+							return me._set_values_for_item_list(r.children);
+						}
 					}
-				}
-			]);
+				]);
+			}
+		catch(err) {
+			console.error(err);
 		}
 	},
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1498,7 +1498,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					}
 				]);
 			}
-		catch(err) {
+		} catch(err) {
 			console.error(err);
 		}
 	},


### PR DESCRIPTION
Additions:
- adds try catch on xcall to log error on console as the failed promise's error is lost on loggers