### PR TITLE
fix: Payment Entry's outstanding amount incorrectly computed

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -174,8 +174,10 @@ class PaymentEntry(AccountsController):
 					d.reference_name, self.party_account_currency)
 
 				for field, value in iteritems(ref_details):
-					if field == 'exchange_rate' or not d.get(field) or force:
+					if field == 'exchange_rate' or not d.get(field):
 						d.set(field, value)
+					elif force:
+						d.db_set(field, value)
 
 	def validate_payment_type(self):
 		if self.payment_type not in ("Receive", "Pay", "Internal Transfer"):
@@ -547,7 +549,7 @@ class PaymentEntry(AccountsController):
 				})
 
 				gl_entries.append(gle)
-			
+
 			if self.total_discounted_amount:
 				for d in self.get("references"):
 					gle = party_gl_dict.copy()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -185,6 +185,7 @@ class SalesInvoice(SellingController):
 		self.update_serial_no()
 
 		if not cint(self.is_pos) == 1 and not self.is_return:
+			self.db_update()
 			self.update_against_document_in_jv()
 
 		self.update_time_sheet(self.name)


### PR DESCRIPTION
- **Sales Order**
    - While creating a  Payment Entry against Sales Order, the outstanding amount is not set to zero if a full payment is made against it.
    - The `d.set` in `set_missing_ref_details` in Payment Entry only updates the values in document not in the database, which let to the outstanding amount not updating in Payment Entry for Sales Order.
- **Sales Invoice**
   - After creating a Payment Entry against Sales Order, when you create a Sales Invoice and check `update_advances_automatically`, the outstanding amount is not set to zero in Payment Entry.
   - This is due to the fact that in `on_submit` the changes are never commited to db and in Payment Entry, in function `get_reference_details`, the frappe.get_doc gets stale value from the database and the outstanding amount in never set to zero.

Steps to Reproduce:
- Create a Sales Order and then create Payment Entry against it.
- After submission, create a Sales Invoice and check `allocate_advances_automatically` and submit it