### PR TITLE
fix: duplicate role expense moudule issue fixed

### DIFF
--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -310,11 +310,12 @@ def install(country=None):
 
 def make_roles(roles=[]):
 	for role in roles:
-		frappe.get_doc({
-			"doctype": "Role",
-			"role_name": role.get("role_name"),
-			"for_mobile_application": role.get("for_mobile_application")
-		}).insert(ignore_permissions=True)
+		if not frappe.db.exists("Role", role.get("role_name")):
+			frappe.get_doc({
+				"doctype": "Role",
+				"role_name": role.get("role_name"),
+				"for_mobile_application": role.get("for_mobile_application")
+			}).insert(ignore_permissions=True)
 
 def set_more_defaults():
 	# Do more setup stuff that can be done here with no dependencies


### PR DESCRIPTION
Problem: while running setup wizard it gives error duplicate Expense Role Module exist