### PR TITLE
fix: set valuation rate if item is new

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -891,8 +891,8 @@ class Item(WebsiteGenerator):
 				frappe.msgprint(msg=_("You have to enable auto re-order in Stock Settings to maintain re-order levels."), title=_("Enable Auto Re-Order"), indicator="orange")
 
 	def validate_valuation_method(self):
-			if not self.valuation_method:
-				self.valuation_method = frappe.db.get_single_value("Stock Settings", "valuation_method")
+		if self.is_new() and not self.valuation_method:
+			self.valuation_method = frappe.db.get_single_value("Stock Settings", "valuation_method")
 
 def get_timeline_data(doctype, name):
 	'''returns timeline data based on stock ledger entry'''


### PR DESCRIPTION
- [Asana](https://app.asana.com/0/1199639423748061/1200322398486412)
- Check for `valuation_method` if the item is being inserted since `valuation_method` is `set_only_once` field.