### PR TITLE
fix: validate requested and transaction date

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -35,24 +35,6 @@ frappe.ui.form.on('Quotation', {
 		frm.trigger("set_dynamic_field_label");
 	},
 
-	requested_delivery_date: function(frm) {
-		let parsed_requested_delivery_date = Date.parse(frm.doc.requested_delivery_date);
-		let parsed_transaction_date = Date.parse(frm.doc.transaction_date);
-	
-		if (parsed_requested_delivery_date < parsed_transaction_date){
-			frappe.msgprint(__("Requested delivery date cannot be before transaction date"));
-		}
-	},
-
-	valid_till: function(frm) {
-		let parsed_valid_till = Date.parse(frm.doc.valid_till);
-		let parsed_transaction_date = Date.parse(frm.doc.transaction_date);
-	
-		if (parsed_valid_till < parsed_transaction_date){
-			frappe.msgprint(__("Valid till date cannot be before transaction date"));
-		}
-	},
-
 	quotation_to: function(frm) {
 		frm.trigger("set_label");
 		frm.trigger("toggle_reqd_lead_customer");

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -35,6 +35,24 @@ frappe.ui.form.on('Quotation', {
 		frm.trigger("set_dynamic_field_label");
 	},
 
+	requested_delivery_date: function(frm) {
+		let parsed_requested_delivery_date = Date.parse(frm.doc.requested_delivery_date);
+		let parsed_transaction_date = Date.parse(frm.doc.transaction_date);
+	
+		if (parsed_requested_delivery_date < parsed_transaction_date){
+			frappe.msgprint(__("Requested delivery date cannot be before transaction date"));
+		}
+	},
+
+	valid_till: function(frm) {
+		let parsed_valid_till = Date.parse(frm.doc.valid_till);
+		let parsed_transaction_date = Date.parse(frm.doc.transaction_date);
+	
+		if (parsed_valid_till < parsed_transaction_date){
+			frappe.msgprint(__("Valid till date cannot be before transaction date"));
+		}
+	},
+
 	quotation_to: function(frm) {
 		frm.trigger("set_label");
 		frm.trigger("toggle_reqd_lead_customer");

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -33,6 +33,9 @@ class Quotation(SellingController):
 			self.with_items = 1
 
 	def validate_valid_till(self):
+		if self.requested_delivery_date and getdate(self.requested_delivery_date) < getdate(self.transaction_date):
+			frappe.throw(_("Requested delivery date cannot be before transaction date"))
+			
 		if self.valid_till and getdate(self.valid_till) < getdate(self.transaction_date):
 			frappe.throw(_("Valid till date cannot be before transaction date"))
 


### PR DESCRIPTION
System allows to set "Requested Delivery Date" back dated with comparison to "Date" calendar field value & save details. 
Asana Task : - https://app.asana.com/0/1200073273462988/1199893804493435

Added an validation from both backend end and frontend to validate - 
1. "**Requested Delivery Date**" back dated with comparison to "**Date**" value.
2. "**Valid Till Date**" back dated with comparison to "**Date**" value.

Below is the Snap and gif attached : -
**BEFORE FIELD BEHAVIOUR**
![QuotationList-Before](https://user-images.githubusercontent.com/80836439/118727204-0bcfe300-b850-11eb-86fb-6fcbb9748028.PNG)

https://user-images.githubusercontent.com/80836439/118727211-0d011000-b850-11eb-9648-0cf6468256d1.mp4

**AFTER FIX : FIELD BEHAVIOUR**
![QuotationList-After-valid-till](https://user-images.githubusercontent.com/80836439/118727243-19856880-b850-11eb-90ed-fc63712d5878.PNG)
![QuotationList-After-req-del-date](https://user-images.githubusercontent.com/80836439/118727247-1a1dff00-b850-11eb-9626-8107f2d46cda.PNG)

https://user-images.githubusercontent.com/80836439/118727248-1ab69580-b850-11eb-9036-944146eb5ae1.mp4

