### PR TITLE
refactor: Authorizenet Integration

### DIFF
--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -314,7 +314,7 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 					.get("description", "")
 
 			if description:
-				result.update({ "description": description})
+				result.update({"description": description})
 
 		elif status == "Failed":
 			description = response_dict.get(

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -56,9 +56,10 @@ Return payment status after processing the payment
 
 import json
 import re
+import datetime
 
 from authorizenet import apicontractsv1
-from authorizenet.apicontrollers import createTransactionController
+from authorizenet.apicontrollers import createTransactionController, getUnsettledTransactionListController
 from authorizenet.constants import constants
 from six.moves.urllib.parse import urlencode
 
@@ -66,8 +67,10 @@ import frappe
 from frappe import _
 from frappe.integrations.utils import create_payment_gateway, create_request_log
 from frappe.model.document import Document
-from frappe.utils import call_hook_method, cstr, get_url
+from frappe.utils import call_hook_method, cstr, get_url, now
+from frappe.utils.data import time_diff_in_seconds
 from frappe.utils.password import get_decrypted_password
+from erpnext.utilities.utils import retry
 
 
 class AuthorizenetSettings(Document):
@@ -84,6 +87,185 @@ class AuthorizenetSettings(Document):
 	def get_payment_url(self, **kwargs):
 		return get_url("./integrations/authorizenet_checkout?{0}".format(urlencode(kwargs)))
 
+def get_order_request_info(reference_doctype, reference_docname):
+	"""Returns the latestt dict containing Integration Request name, status and errortext if one
+	is found for the provided reference doctype and docname.
+
+	Otherwise return False if no Integration Request is found.
+	"""
+	# Check if there was already a request for this api call
+	# and return last attempt
+	existing_requests = frappe.get_all(
+		"Integration Request",
+		fields=["name", "status", "error", "modified"],
+		filters={
+			"reference_doctype": reference_doctype,
+			"reference_docname": reference_docname,
+			"integration_request_service": "Authorizenet",
+			"integration_type": "Host"
+		},
+		order_by="modified desc"
+	)
+
+	print("--- Existing IR: ", existing_requests)
+
+	if len(existing_requests) > 0:
+		request = existing_requests[0]
+		return request
+
+	return False
+
+def query_successful_authnet_transaction(request):
+	merchantAuth = request.merchant_auth or None
+	order_ref = request.reference_doc.name
+	amount = request.amount
+
+	if merchantAuth is None:
+		merchantAuth = apicontractsv1.merchantAuthenticationType()
+		merchantAuth.name = frappe.db.get_single_value("Authorizenet Settings", "api_login_id")
+		merchantAuth.transactionKey = get_decrypted_password('Authorizenet Settings', 'Authorizenet Settings',
+			fieldname='api_transaction_key', raise_exception=False)
+
+	# set sorting parameters
+	sorting = apicontractsv1.TransactionListSorting()
+	sorting.orderBy = apicontractsv1.TransactionListOrderFieldEnum.id
+	sorting.orderDescending = True
+
+	# set paging and offset parameters
+	paging = apicontractsv1.Paging()
+	# Paging limit can be up to 1000 for this request
+	paging.limit = 20
+	paging.offset = 1
+
+	transactionListRequest = apicontractsv1.getTransactionListRequest()
+	transactionListRequest.merchantAuthentication = merchantAuth
+	transactionListRequest.refId = order_ref
+	transactionListRequest.sorting = sorting
+	transactionListRequest.paging = paging
+
+	unsettledTransactionListController = getUnsettledTransactionListController(transactionListRequest)
+	if not frappe.db.get_single_value("Authorizenet Settings", "sandbox_mode"):
+		unsettledTransactionListController.setenvironment(constants.PRODUCTION)
+
+	unsettledTransactionListController.execute()
+
+	# Work on the response
+	response = unsettledTransactionListController.getresponse()
+
+	if response is not None:
+		if response.messages.resultCode == apicontractsv1.messageTypeEnum.Ok:
+			if hasattr(response, 'transactions'):
+				print('Successfully retrieved transaction list.')
+				if response.messages is not None:
+					print('Message Code: %s' % response.messages.message[0]['code'].text)
+					print('Message Text: %s' % response.messages.message[0]['text'].text)
+					print('Total Number In Results: %s' % response.totalNumInResultSet)
+					print()
+
+				for transaction in response.transactions.transaction:
+					print(transaction)
+					print('Transaction Id: %s' % transaction.transId)
+					print('Transaction Status: %s' % transaction.transactionStatus)
+					if hasattr(transaction, 'accountType'):
+						print('Account Type: %s' % transaction.accountType)
+					print('Settle Amount: %.2f' % transaction.settleAmount)
+					if hasattr(transaction, 'profile'):
+						print('Customer Profile ID: %s' % transaction.profile.customerProfileId)
+					print()
+
+					if (transaction.transactionStatus == "capturedPendingSettlement" or \
+						transaction.transactionStatus == "authorizedPendingCapture") and \
+						transaction.invoiceNumber == order_ref and transaction.amount == amount:
+						return transaction
+			else:
+				if response.messages is not None:
+					print('Failed to get transaction list.')
+					print('Code: %s' % (response.messages.message[0]['code'].text))
+					print('Text: %s' % (response.messages.message[0]['text'].text))
+
+				return False
+		else:
+			if response.messages is not None:
+				print('Failed to get transaction list.')
+				print('Code: %s' % (response.messages.message[0]['code'].text))
+				print('Text: %s' % (response.messages.message[0]['text'].text))
+
+			return False
+	else:
+		print('Error. No response received.')
+		return False
+
+	return False
+
+@frappe.whitelist(allow_guest=True)
+def get_status(data):
+	if isinstance(data, str):
+		data = json.loads(data)
+		data = frappe._dict(data)
+
+	# sanity gate keeper. Don't process anything without reference doctypes
+	if not data.reference_doctype or not data.reference_docname:
+		return {
+			"status": "Failed",
+			"description": "Invalid request. Submitted data contains no order reference. This seems to be an internal error. Please contact support."
+		}
+
+	# fetch previous requests info
+	request_info = get_order_request_info(data.reference_doctype, data.reference_docname)
+
+	# and document references
+	pr = frappe.get_doc(data.reference_doctype, data.reference_docname)
+	reference_doc = frappe.get_doc(pr.reference_doctype, pr.reference_name)
+
+	if request_info:
+		status = request_info.get("status")
+		integration_request = frappe.get_doc("Integration Request", request_info.name)
+
+		if status == "Queued":
+			# we don't want to wait forever for a failed request that never updated
+			# the integration request status
+			time_elapsed_since_update = time_diff_in_seconds(now(), request_info.modified)
+			if time_elapsed_since_update < 60:
+				return {
+					"status": "Queued",
+					"wait": 5000
+				}
+			else:
+				# assume dropped request and flag as failed. Then restart call process with new
+				# integration request.
+				integration_request.error = "[Timeout] Integration Request lasted longer than 60 seconds. Assuming dropped request."
+				integration_request.update_status(data, "Failed")
+				integration_request = None
+				early_exit = False
+				return {
+					"status": "Failed",
+					"type": "ProcessorTimeout",
+					"description": "Request to credit card processor Timed out."
+				}
+		elif status == "Completed":
+			return {
+				"status": "Completed"
+			}
+
+		if status == "Failed":
+			if "declined" in (integration_request.error or "").lower():
+				return {
+					"status": "Failed",
+					"type": "Validation",
+					"description": integration_request.error
+				}
+
+			# don't early exit on failed. Means we are retrying a new card
+			return {
+				"status": "Failed",
+				"type": "Unhandled",
+				"description": integration_request.error
+			}
+	
+	return {
+		"status": "NotFound"
+	}
+
 
 @frappe.whitelist(allow_guest=True)
 def charge_credit_card(data, card_number, expiration_date, card_code):
@@ -93,27 +275,184 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 	data = json.loads(data)
 	data = frappe._dict(data)
 
+	# sanity gate keeper. Don't process anything without reference doctypes
+	if not data.reference_doctype or not data.reference_docname:
+		return {
+			"status": "Failed",
+			"description": "Invalid request. Submitted data contains no order reference. This seems to be an internal error. Please contact support."
+		}
+
+	# fetch previous requests info
+	request_info = get_order_request_info(data.reference_doctype, data.reference_docname)
+
+	# and document references
+	pr = frappe.get_doc(data.reference_doctype, data.reference_docname)
+	reference_doc = frappe.get_doc(pr.reference_doctype, pr.reference_name)
+
+	# Sanity check. Make sure to not process card if a previous request was fullfilled
+	status = get_status(data)
+	if status.get("status") != "Failed" and status.get("status") != "NotFound":
+		return status
+
 	# Create Integration Request
 	integration_request = create_request_log(data, "Host", "Authorizenet")
 
-	# Authenticate with Authorizenet
+	# Setup Authentication on Authorizenet
 	merchant_auth = apicontractsv1.merchantAuthenticationType()
 	merchant_auth.name = frappe.db.get_single_value("Authorizenet Settings", "api_login_id")
 	merchant_auth.transactionKey = get_decrypted_password('Authorizenet Settings', 'Authorizenet Settings',
 		fieldname='api_transaction_key', raise_exception=False)
 
+	# create request dict to ease passing around data
+	request = frappe._dict({
+		"pr": 	pr,
+		"reference_doc": reference_doc,
+		"data": data,
+		"merchant_auth": merchant_auth,
+		"integration_request": integration_request,
+	 	"card_number": card_number,
+		"expiration_date": expiration_date, 
+		"card_code": card_code
+	})
+
+	# Charge chard step
+	def tryChargeCard(i):
+		# ping authnet first to check if transaction was previously made
+		order_transaction = query_successful_authnet_transaction(request)
+
+		# if transaction was already recorded on authnet side, update integration
+		# request and return success
+		if order_transaction:
+			print("-- Found AUTH NET Transaction...")
+			print(order_transaction)
+			return frappe._dict({
+				"status": "Completed"
+			})
+		else:
+			print("No previous Successful AUTH NET Transaction found...")
+
+
+		# Otherwise, begine charging card
+		response = authnet_charge(request)
+
+		# translate result to response payload
+		status = "Failed"
+		if response is not None:
+			print("Response: ", response.messages.resultCode)
+			# Check to see if the API request was successfully received and acted upon
+			if response.messages.resultCode == "Ok" and hasattr(response.transactionResponse, 'messages') is True:
+				status = "Completed"
+
+		response_dict = to_dict(response)
+		result = frappe._dict({
+			"status": status
+		})
+		print("RESPONSE: ", response)
+
+		if status == "Completed":
+			description = response_dict.get(
+				"transactionResponse", {}) \
+					.get("messages",{}) \
+					.get("message", {}) \
+					.get("description", "")
+
+			if description:
+				result.update({ "description": description})
+
+		elif status == "Failed":
+			description = response_dict.get(
+				"transactionResponse", {}) \
+					.get("errors",{}) \
+					.get("error", {}) \
+					.get("errorText", "Unknown Error")
+
+			if description:
+				result.update({ "description": description})
+
+			integration_request.error = description
+		else:
+			# TODO: Check what errors would trickle here...
+			result.update({
+				"description": "Something went wrong while trying to complete the transaction. Please try again."
+			})
+
+		# update integration request with result
+		integration_request.update_status(data, status)
+
+		# Finally update PR and order
+		if status != "Failed":
+			try:
+				pr.run_method("on_payment_authorized", status)
+			except Exception as ex:
+				# we have a payment, however an internal process broke
+				# so, log it and add a comment on the reference document.
+				# continue to process the request as if it was succesful
+				traceback = frappe.get_traceback()
+				err_doc = frappe.log_error(message=traceback , title="Error processing credit card")
+				request.reference_doc.add_comment("Comment",
+					text="[INTERNAL ERROR] There was a problem while processing this order's payment.\n"+
+					"The transaction was record successfully and the card was charged.\n\n" +
+					"However, please contact support to track down this issue and provide the following " +
+					"error id: " + err_doc.name
+				)
+
+		# Flag declined transactions as a validation error which the user should correct.
+		if "declined" in (result.get("description") or "").lower():
+			result.type = "Validation"
+
+		if "duplicate" in (result.get("description") or "").lower():
+			result.type = "Duplicate"
+
+		return result
+
+	# validate result to trigger a retry or complete calls
+	def chargeResultPredicate(result, i):
+		return result
+
+	# handle exceptions during card charges
+	def chargeExceptionPredicate(exception, i):
+		print("[Charge Exception Predicate: ", i, "] ", exception)
+		result_obj = {}
+
+		if isinstance(exception, Exception):
+			description = "There was an internal error while processing your payment." + \
+				"To avoid double charges, please contact us."
+			traceback = frappe.get_traceback()
+			print(traceback)
+
+			frappe.log_error(message=traceback , title="Error processing credit card")
+			result_obj.update({
+				"status": "Failed",
+				"description": description,
+				"error": exception.message
+			})
+
+		print("[Charge Exception Predicate: ", i, "] ", result_obj)
+
+		return result_obj
+
+	result = retry(tryChargeCard, 3, chargeResultPredicate, chargeExceptionPredicate)
+
+	return result
+
+def authnet_charge(request):
+
+	print("--------------------------------------")
+	print(request)
+
+	# data refs
+	data = request.data
+	reference_doc = request.reference_doc
+
 	# Create the payment data for a credit card
 	credit_card = apicontractsv1.creditCardType()
-	credit_card.cardNumber = card_number
-	credit_card.expirationDate = expiration_date
-	credit_card.cardCode = card_code
+	credit_card.cardNumber = request.card_number
+	credit_card.expirationDate = request.expiration_date
+	credit_card.cardCode = request.card_code
 
 	# Add the payment data to a paymentType object
 	payment = apicontractsv1.paymentType()
 	payment.creditCard = credit_card
-
-	pr = frappe.get_doc(data.reference_doctype, data.reference_docname)
-	reference_doc = frappe.get_doc(pr.reference_doctype, pr.reference_name).as_dict()
 
 	customer_address = apicontractsv1.customerAddressType()
 	customer_address.firstName = data.payer_name
@@ -138,6 +477,14 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 
 		line_items.lineItem.append(line_item)
 
+	# Adjust duplicate window to avoid duplicate window issues on declines
+	duplicateWindowSetting = apicontractsv1.settingType()
+	duplicateWindowSetting.settingName = "duplicateWindow"
+	# seconds before an identical transaction can be submitted
+	duplicateWindowSetting.settingValue = "10"
+	settings = apicontractsv1.ArrayOfSetting()
+	settings.setting.append(duplicateWindowSetting)
+
 	# Create a transactionRequestType object and add the previous objects to it.
 	transaction_request = apicontractsv1.transactionRequestType()
 	transaction_request.transactionType = "authCaptureTransaction"
@@ -146,55 +493,31 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 	transaction_request.order = order
 	transaction_request.billTo = customer_address
 	transaction_request.lineItems = line_items
+	transaction_request.transactionSettings = settings
 
 	# Assemble the complete transaction request
 	create_transaction_request = apicontractsv1.createTransactionRequest()
-	create_transaction_request.merchantAuthentication = merchant_auth
+	create_transaction_request.merchantAuthentication = request.merchant_auth
 	create_transaction_request.transactionRequest = transaction_request
+	create_transaction_request.refId = reference_doc.name
 
 	# Create the controller
 	createtransactioncontroller = createTransactionController(create_transaction_request)
 	if not frappe.db.get_single_value("Authorizenet Settings", "sandbox_mode"):
+		print("Using production env...")
 		createtransactioncontroller.setenvironment(constants.PRODUCTION)
+	print("...Send charge request...")
 	createtransactioncontroller.execute()
 
-	response = createtransactioncontroller.getresponse()
-
-	status = "Failed"
-	if response is not None:
-		# Check to see if the API request was successfully received and acted upon
-		if response.messages.resultCode == "Ok" and hasattr(response.transactionResponse, 'messages') is True:
-			status = "Completed"
-
-	if status != "Failed":
-		try:
-			pr.run_method("on_payment_authorized", status)
-		except Exception as ex:
-			raise ex
-
-	response_dict = to_dict(response)
-	integration_request.update_status(data, status)
-	description = "Something went wrong while trying to complete the transaction. Please try again."
-
-	if status == "Completed":
-		description = response_dict.get("transactionResponse").get("messages").get("message").get("description")
-	elif status == "Failed":
-		description = error_text = response_dict.get("transactionResponse").get("errors").get("error").get("errorText")
-		integration_request.error = error_text
-		integration_request.save(ignore_permissions=True)
-
-	return frappe._dict({
-		"status": status,
-		"description": description
-	})
-
+	return createtransactioncontroller.getresponse()
 
 def to_dict(response):
 	response_dict = {}
 	if response.getchildren() == []:
 		return response.text
-	else:
-		for elem in response.getchildren():
-			subdict = to_dict(elem)
-			response_dict[re.sub('{.*}', '', elem.tag)] = subdict
+
+	for elem in response.getchildren():
+		subdict = to_dict(elem)
+		response_dict[re.sub('{.*}', '', elem.tag)] = subdict
+
 	return response_dict

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -279,7 +279,7 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 		"card_code": card_code
 	})
 
-	# Charge chard step
+	# Charge card step
 	def tryChargeCard(i):
 		# ping authnet first to check if transaction was previously made
 		order_transaction = query_successful_authnet_transaction(request)

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -324,7 +324,7 @@ def charge_credit_card(data, card_number, expiration_date, card_code):
 					.get("errorText", "Unknown Error")
 
 			if description:
-				result.update({ "description": description})
+				result.update({"description": description})
 
 			integration_request.error = description
 		else:

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -151,9 +151,9 @@ def query_successful_authnet_transaction(request):
 	# Work on the response
 	response = unsettledTransactionListController.getresponse()
 
-	if response is not None:
-		if response.messages.resultCode == apicontractsv1.messageTypeEnum.Ok:
-			if hasattr(response, 'transactions'):
+	if response is not None and \
+		response.messages.resultCode == apicontractsv1.messageTypeEnum.Ok and \
+		hasattr(response, 'transactions'):
 				for transaction in response.transactions.transaction:
 					if (transaction.transactionStatus == "capturedPendingSettlement" or \
 						transaction.transactionStatus == "authorizedPendingCapture") and \

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -104,7 +104,8 @@ def get_order_request_info(reference_doctype, reference_docname):
 			"integration_request_service": "Authorizenet",
 			"integration_type": "Host"
 		},
-		order_by="modified desc"
+		order_by="modified desc",
+		limit=1
 	)
 
 	if len(existing_requests) > 0:

--- a/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
+++ b/erpnext/erpnext_integrations/doctype/authorizenet_settings/authorizenet_settings.py
@@ -160,7 +160,7 @@ def query_successful_authnet_transaction(request):
 						return transaction
 	return False
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_status(data):
 	if isinstance(data, str):
 		data = json.loads(data)
@@ -230,7 +230,7 @@ def get_status(data):
 	}
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def charge_credit_card(data, card_number, expiration_date, card_code):
 	"""
 	Charge a credit card

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -22,7 +22,7 @@
 *                      another status check request in milliseconds.
 */
 
-frappe.ready(function() {
+frappe.ready(function () {
 	const data = context.replace(/'/g, '"');
 
 	/**
@@ -30,7 +30,7 @@ frappe.ready(function() {
 	 * @param {*} data Order information data structure. See authorizenet_settings.py
 	 * @returns Promise<void>
 	 */
-	const fetch_status = async function(data) {
+	const fetch_status = async function (data) {
 		const r = await frappe.call({
 			method: "erpnext.erpnext_integrations.doctype.authorizenet_settings.authorizenet_settings.get_status",
 			freeze: true,
@@ -52,8 +52,8 @@ frappe.ready(function() {
 	 * @param {int} maxTimeouts Maximum number of timeouts before a hard error
 	 * @returns Promise<void>
 	 */
-	const check_status = async function(data, label, on_success, on_fail, counter, maxTimeouts) {
-		if ( !maxTimeouts) {
+	const check_status = async function (data, label, on_success, on_fail, counter, maxTimeouts) {
+		if (!maxTimeouts) {
 			maxTimeouts = 6; // 6 times x 5 secs = 30secs
 		}
 		// switch ui to display message to user
@@ -64,19 +64,19 @@ frappe.ready(function() {
 			// Process status result
 			await process_status(status, label, on_success, on_fail, counter, maxTimeouts);
 		} catch (err) {
-			if ( err ) {
-				if ( !navigator.onLine || err.status === 0 ) {
-					if ( counter < maxTimeouts ) {
-						setTimeout(() => check_status(data, 
+			if (err) {
+				if (!navigator.onLine || err.status === 0) {
+					if (counter < maxTimeouts) {
+						setTimeout(() => check_status(data,
 							"Detected a network problem. Trying to reconnect, please wait...",
-							on_success, 
-							on_fail, 
-							counter+1), 
-							5000, 
+							on_success,
+							on_fail,
+							counter + 1),
+							5000,
 							maxTimeouts
 						);
 						return; // only early exit when queuing up a delayed check_status.
-					} else if ( on_fail ) {
+					} else if (on_fail) {
 						on_fail({
 							"status": "Failed",
 							"type": "HardError",
@@ -87,7 +87,7 @@ frappe.ready(function() {
 				}
 			}
 
-			if ( on_fail ) {
+			if (on_fail) {
 				on_fail({}, err);
 			}
 		}
@@ -97,7 +97,7 @@ frappe.ready(function() {
 	 * Hides form and displays message label.
 	 * @param {string} label Feedback text to display to the user
 	 */
-	const start_status_check = function(label) {
+	const start_status_check = function (label) {
 		$('#please-wait').text(__(label || "Please Wait..."));
 		$('#please-wait').fadeIn('fast');
 		$('#payment-form').fadeOut('fast');
@@ -106,7 +106,7 @@ frappe.ready(function() {
 	/**
 	 * Displays the credit card form and hides message label.
 	 */
-	const show_form = function() {
+	const show_form = function () {
 		$('#please-wait').fadeOut('fast');
 		$('#payment-form').fadeIn('fast');
 	}
@@ -122,56 +122,56 @@ frappe.ready(function() {
 	 * @param {int} maxTimeouts Maximum number of timeouts before a hard error
 	 * @returns Promise<void>
 	 */
-	const process_status = async function(status, label, on_success, on_fail, counter, maxTimeouts) {
-		if ( !counter ) {
+	const process_status = async function (status, label, on_success, on_fail, counter, maxTimeouts) {
+		if (!counter) {
 			counter = 1;
 		}
-		if ( !maxTimeouts) {
+		if (!maxTimeouts) {
 			maxTimeouts = 6;
 		}
 
-		if ( status.status === "NotFound" ) {
+		if (status.status === "NotFound") {
 			// No previous PR request found. So lets display the UI
 			$('#please-wait').fadeOut('fast');
 			$('#payment-form').fadeIn('fast');
 
-		} else if ( status.status === "Completed" ) {
+		} else if (status.status === "Completed") {
 			// Redirect user to payment success page
-			if ( on_success ) {
+			if (on_success) {
 				await on_success(status);
 			}
 			$('#please-wait').text(__("Payment was successful! Please wait while we redirect you."));
 
 			window.location.href = "/integrations/payment-success";
-		} else if (status.status === "Queued" ) {
+		} else if (status.status === "Queued") {
 			// Processing not completed. Wait for Queue
 			$('#please-wait').text(__("Request is taking longer than expected. Please wait..."));
-			setTimeout(function() { check_status(data, label, on_success, on_fail, counter+1, maxTimeouts) }, status.wait );
+			setTimeout(function () { check_status(data, label, on_success, on_fail, counter + 1, maxTimeouts) }, status.wait);
 
 		} else if (status.status === "Failed") {
-			if ( status.type === "Validation" ) {
+			if (status.type === "Validation") {
 				// On validation errors, re-enable form
 				frappe.msgprint(__(status.description || ""));
 				show_form();
 				$('#submit').prop('disabled', false);
 				$('#submit').html(__('Retry'));
 
-				if ( on_fail ) {
+				if (on_fail) {
 					await on_fail(status);
 				}
-			} else if ( status.type === "HardError" ) {
-				if ( status.description ) {
+			} else if (status.type === "HardError") {
+				if (status.description) {
 					$('#please-wait').text(__(status.description));
 				} else {
 					$('#please-wait').text(__("There was an uhandled internal error. Please try again or contact support."));
 				}
-				if ( on_fail ) {
+				if (on_fail) {
 					await on_fail(status);
 				}
 			} else {
 				// Anything else is a failed request. Lets figure out if its a hard error
 				// or a validation one on the callback
-				if ( on_fail ) {
+				if (on_fail) {
 					await on_fail(status);
 				}
 			}
@@ -184,7 +184,7 @@ frappe.ready(function() {
 	 * @param {onCardProcessFail} on_fail A Failure function callback
 	 * @returns Promise<void>
 	 */
-	const charge = async function(card, on_success, on_fail) {
+	const charge = async function (card, on_success, on_fail) {
 		start_status_check("Processing. Please Wait...");
 		try {
 			const r = await frappe.call({
@@ -195,23 +195,24 @@ frappe.ready(function() {
 					"expiration_date": card.expirationDate,
 					"card_code": card.cardCode,
 					"data": data
-				}});
+				}
+			});
 			await process_status(r.message, "Processing. Please wait...", on_success, on_fail);
-		} catch(err) {
+		} catch (err) {
 			console.error(err);
 			on_fail({}, err);
 		}
 	}
 
 	// Handles credit card submit behaviour
-	$('#submit').on("click", async function(e) {
+	$('#submit').on("click", async function (e) {
 		let data = context.replace(/'/g, '"');
 		e.preventDefault();
 
 		let cardHolderName = document.getElementById('cardholder-name').value;
 		let cardHolderEmail = document.getElementById('cardholder-email').value;
 		let cardNumberWithSpaces = document.getElementById('card-number').value;
-		let cardNumber = cardNumberWithSpaces.replace(/ /g,"");
+		let cardNumber = cardNumberWithSpaces.replace(/ /g, "");
 		let expirationMonth = document.getElementById('card-expiry-month').value;
 		let expirationYear = document.getElementById('card-expiry-year').value;
 		let expirationDate = expirationYear.concat("-").concat(expirationMonth);
@@ -230,7 +231,7 @@ frappe.ready(function() {
 		if (!cardHolderEmail) {
 			frappe.throw(__("Card Holder Email is mandatory."));
 		}
-		
+
 		if (!validate_email(cardHolderEmail)) {
 			frappe.throw(__("Card Holder Email is invalid."));
 		}
@@ -239,15 +240,15 @@ frappe.ready(function() {
 			frappe.throw(__("Card Number is Invalid."));
 		}
 
-		if(cardNumber.length < 13 || cardNumber.length > 16){
+		if (cardNumber.length < 13 || cardNumber.length > 16) {
 			frappe.throw(__("Card Number length should be between 13 and 16 characters"));
 		}
 
-		if(expirationMonth === "00" || expirationMonth.length !== 2 || expirationYear === "0000" || expirationYear.length !== 4){
+		if (expirationMonth === "00" || expirationMonth.length !== 2 || expirationYear === "0000" || expirationYear.length !== 4) {
 			frappe.throw(__("Card Expiration Date is invalid"));
 		}
 
-		if(cardCode.length < 3 || cardCode.length > 4){
+		if (cardCode.length < 3 || cardCode.length > 4) {
 			frappe.throw(__("Card Code length should be between 3 and 4 characters"));
 		}
 
@@ -256,33 +257,33 @@ frappe.ready(function() {
 
 		// issue credit card charge
 		await charge(card, null, async (status, err) => {
-			if ( err ) {
-				if ( !navigator.onLine || err.status === 0 ) {
+			if (err) {
+				if (!navigator.onLine || err.status === 0) {
 					// We lost connection or timed out
 					// Check status until network is back or timeout again
 					// Default should be around 6 times or 30 seconds.
-					check_status(data, 
+					check_status(data,
 						"Detected a network problem. Trying to reconnect, please wait...",
 						null, null, 0);
 				}
 			}
 
-			if ( status.status === "Fail" && status.type === "Duplicate" ) {
+			if (status.status === "Fail" && status.type === "Duplicate") {
 				// Allow up to one more request after a duplicate with a 10 second delay.
 				// This can happen if a card is decliened but the next request is sent before
 				// the duplicate window guard window.
-				setTimeout(() =>charge(card), 10000);
+				setTimeout(() => charge(card), 10000);
 			}
 		});
 	});
 
 	// Ensures only digits are entered on digit fields
 	$('input[data-validation="digit"]')
-		.on("paste", function(e) {
+		.on("paste", function (e) {
 			if (e.originalEvent.clipboardData.getData('text').match(/[^\d]/))
 				e.preventDefault(); //prevent the default behaviour
 		})
-		.keypress(function(event) {
+		.keypress(function (event) {
 			return (event.charCode !== 8 && event.charCode === 0 || (event.charCode >= 48 && event.charCode <= 57));
 		});
 
@@ -297,7 +298,7 @@ frappe.ready(function() {
 	});
 
 	// ping server first to check if this PR was already fullfilled.
-	check_status(data, "Loading...", null, async function(status, err) {
+	check_status(data, "Loading...", null, async function (status, err) {
 		// During any soft failure, display card form.
 		show_form();
 	}, 0);

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -104,7 +104,7 @@ frappe.ready(function() {
 	}
 
 	/**
-	 * Displays the credit card form and mides message label.
+	 * Displays the credit card form and hides message label.
 	 */
 	const show_form = function() {
 		$('#please-wait').fadeOut('fast');

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -1,87 +1,284 @@
-$('#submit').on("click", function(e) {
-	let data = context.replace(/'/g, '"');
-	e.preventDefault();
+/**
+ * On Success Callback
+ * @typedef {function(object):Promise<void>} onCardProcessSuccess
+ * @callback onCardProcessSuccess
+ * @param {object} status The returned status object from the server
+ */
 
-	let cardHolderName = document.getElementById('cardholder-name').value;
-	let cardHolderEmail = document.getElementById('cardholder-email').value;
-	let cardNumberWithSpaces = document.getElementById('card-number').value;
-	let cardNumber = cardNumberWithSpaces.replace(/ /g,"");
-	let expirationMonth = document.getElementById('card-expiry-month').value;
-	let expirationYear = document.getElementById('card-expiry-year').value;
-	let expirationDate = expirationYear.concat("-").concat(expirationMonth);
-	let cardCode = document.getElementById('card-code').value;
-	let isValidCard = frappe.cardValidator.number(cardNumber);
+/**
+ * On Failure Callback
+ * @typedef {function(object):Promise<void>} onCardProcessFail
+ * @callback onCardProcessFail
+ * @param {object} status returned status object from the server
+ * @param {Exception} err If one occurs, the exception instance.
+ */
 
-	if (!cardHolderName) {
-		frappe.throw(__("Card Holder Name is mandatory."));
+/**
+* @typedef {Object} ProcessStatus
+* @property {string} status Status enum. Possible values: "Completed", "NotFound", "Queued", "Failed".
+* @property {string} type On a failed request. The type is one of: "Validation", "HardError", "Timeout", "Unhandled"
+* @property {string} description A reason message for the status returned.
+* @property {int} wait An amount of time the client should wait before issuing 
+*                      another status check request in milliseconds.
+*/
+
+frappe.ready(function() {
+	const data = context.replace(/'/g, '"');
+
+	/**
+	 * Fetches payment request status information
+	 * @param {*} data Order information data structure. See authorizenet_settings.py
+	 */
+	const fetch_status = async function(data) {
+		const r = await frappe.call({
+			method: "erpnext.erpnext_integrations.doctype.authorizenet_settings.authorizenet_settings.get_status",
+			freeze: true,
+			args: {
+				"data": data
+			}
+		});
+
+		return r.message;
 	}
 
-	if (!cardHolderEmail) {
-		frappe.throw(__("Card Holder Email is mandatory."));
-	}
-	
-	if (!validate_email(cardHolderEmail)) {
-		frappe.throw(__("Card Holder Email is invalid."));
-	}
+	/**
+	 * Starts status request and UI updates to handle PR status check.
+	 * @param {object} data Order information data structure. See authorizenet_settings.py
+	 * @param {string} label Status label to display when processing status
+	 * @param {onCardProcessSuccess} on_success a Success function callback. 
+	 * @param {onCardProcessFail} on_fail A Failure function callback
+	 */
+	const check_status = async function(data, label, on_success, on_fail, counter, maxTimeouts) {
+		if ( !maxTimeouts) {
+			maxTimeouts = 6; // 6 times x 5 secs = 30secs
+		}
+		// switch ui to display message to user
+		start_status_check(label);
+		try {
+			const status = await fetch_status(data);
 
-	if (!validate_email(cardHolderEmail)) {
-		frappe.throw(__("Card Holder Email is invalid."));
-	}
+			// Process status result
+			await process_status(status, label, on_success, on_fail);
+		} catch (err) {
 
-	if (!isValidCard.isPotentiallyValid) {
-		frappe.throw(__("Card Number is Invalid."));
-	}
+			if ( err ) {
+				if ( !navigator.onLine || err.status === 0 ) {
+					if ( counter < maxTimeouts ) {
+						setTimeout(() => check_status(data, 
+							"Detected a network problem. Trying to reconnect, please wait...",
+							on_success, 
+							on_fail, 
+							counter+1), 
+							5000, 
+							maxTimeouts
+						);
+						return;
+					}
+				}
+			}
 
-	if(cardNumber.length < 13 || cardNumber.length > 16){
-		frappe.throw(__("Card Number length should be between 13 and 16 characters"));
-	}
-
-	if(expirationMonth === "00" || expirationMonth.length !== 2 || expirationYear === "0000" || expirationYear.length !== 4){
-		frappe.throw(__("Card Expiration Date is invalid"));
-	}
-
-	if(cardCode.length < 3 || cardCode.length > 4){
-		frappe.throw(__("Card Code length should be between 3 and 4 characters"));
-	}
-
-	$('#submit').prop('disabled', true);
-	$('#submit').html(__('Processing...'));
-
-	frappe.call({
-		method: "erpnext.erpnext_integrations.doctype.authorizenet_settings.authorizenet_settings.charge_credit_card",
-		freeze: true,
-		args: {
-			"card_number": cardNumber,
-			"expiration_date": expirationDate,
-			"card_code": cardCode,
-			"data": data
-		},
-		callback: function(r) {
-			if (r.message.status === "Completed") {
-				window.location.href = "/integrations/payment-success";
-			} else {
-				frappe.msgprint(__(`${r.message.description}`));
-				$('#submit').prop('disabled', false);
-				$('#submit').html(__('Retry'));
+			if ( on_fail ) {
+				on_fail({}, err);
 			}
 		}
-	});
-});
+	}
 
-$('input[data-validation="digit"]')
-	.on("paste", function(e) {
-		if (e.originalEvent.clipboardData.getData('text').match(/[^\d]/))
-			e.preventDefault(); //prevent the default behaviour
-	})
-	.keypress(function(event) {
-		return (event.charCode !== 8 && event.charCode === 0 || (event.charCode >= 48 && event.charCode <= 57));
+	/**
+	 * Hides form and displays message label.
+	 * @param {string} label Feedback text to display to the user
+	 */
+	const start_status_check = function(label) {
+		$('#please-wait').text(label || "Please Wait...");
+		$('#please-wait').fadeIn('fast');
+		$('#payment-form').fadeOut('fast');
+	}
+
+	/**
+	 * Displays the credit card form and mides message label.
+	 */
+	const show_form = function() {
+		$('#please-wait').fadeOut('fast');
+		$('#payment-form').fadeIn('fast');
+	}
+
+
+	/**
+	 * Helper function, all status descitions 
+	 * @param {ProcessStatus} status The status object sent from the backend
+	 * @param {string} label A label to display to the user during processing
+	 * @param {onCardProcessSuccess} on_success a Success function callback. 
+	 * @param {onCardProcessFail} on_fail A Failure function callback
+	 */
+	const process_status = async function(status, label, on_success, on_fail, counter, maxTimeouts) {
+		if ( !counter ) {
+			counter = 1;
+		}
+		if ( !maxTimeouts) {
+			maxTimeouts = 6;
+		}
+
+		console.log("Processing status: ", status);
+
+		if ( status.status === "NotFound" ) {
+			// No previous PR request found. So lets display the UI
+			$('#please-wait').fadeOut('fast');
+			$('#payment-form').fadeIn('fast');
+
+		} else if ( status.status === "Completed" ) {
+			// Redirect user to payment success page
+			if ( on_success ) {
+				await on_success(status);
+			}
+			$('#please-wait').text("Payment was successful. Please wait while we redirect you.");
+
+			window.location.href = "/integrations/payment-success";
+		} else if (status.status === "Queued" ) {
+			// Processing not completed. Wait for Queue
+			setTimeout(function() { check_status(data, label, on_success, on_fail, counter+1, maxTimeouts) }, status.wait );
+
+		} else if (status.status === "Failed") {
+			if ( status.type === "Validation" ) {
+				// On validation errors, re-enable form
+				frappe.msgprint(__(`${status.description}`));
+				show_form();
+				$('#submit').prop('disabled', false);
+				$('#submit').html(__('Retry'));
+
+				if ( on_fail ) {
+					await on_fail(status);
+				}
+			} else {
+				// Anything else is a failed request. Lets figure out if its a hard error
+				// or a validation one on the callback
+				if ( on_fail ) {
+					await on_fail(status);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Starts card processing
+	 * @param {onCardProcessSuccess} on_success a Success function callback. 
+	 * @param {onCardProcessFail} on_fail A Failure function callback
+	 * @returns Promise<void>
+	 */
+	const charge = async function(card, on_success, on_fail) {
+		start_status_check("Processing. Please Wait...");
+		try {
+			const r = await frappe.call({
+				method: "erpnext.erpnext_integrations.doctype.authorizenet_settings.authorizenet_settings.charge_credit_card",
+				freeze: true,
+				args: {
+					"card_number": card.cardNumber,
+					"expiration_date": card.expirationDate,
+					"card_code": card.cardCode,
+					"data": data
+				}});
+			await process_status(r.message, "Processing. Please wait...", on_success, on_fail);
+		} catch(err) {
+			console.error(err);
+			on_fail({}, err);
+		}
+	}
+
+	// Handles credit card submit behaviour
+	$('#submit').on("click", async function(e) {
+		let data = context.replace(/'/g, '"');
+		e.preventDefault();
+
+		let cardHolderName = document.getElementById('cardholder-name').value;
+		let cardHolderEmail = document.getElementById('cardholder-email').value;
+		let cardNumberWithSpaces = document.getElementById('card-number').value;
+		let cardNumber = cardNumberWithSpaces.replace(/ /g,"");
+		let expirationMonth = document.getElementById('card-expiry-month').value;
+		let expirationYear = document.getElementById('card-expiry-year').value;
+		let expirationDate = expirationYear.concat("-").concat(expirationMonth);
+		let cardCode = document.getElementById('card-code').value;
+		let isValidCard = frappe.cardValidator.number(cardNumber);
+		const card = {
+			cardNumber,
+			expirationDate,
+			cardCode
+		}
+
+		if (!cardHolderName) {
+			frappe.throw(__("Card Holder Name is mandatory."));
+		}
+
+		if (!cardHolderEmail) {
+			frappe.throw(__("Card Holder Email is mandatory."));
+		}
+		
+		if (!validate_email(cardHolderEmail)) {
+			frappe.throw(__("Card Holder Email is invalid."));
+		}
+
+		if (!validate_email(cardHolderEmail)) {
+			frappe.throw(__("Card Holder Email is invalid."));
+		}
+
+		if (!isValidCard.isPotentiallyValid) {
+			frappe.throw(__("Card Number is Invalid."));
+		}
+
+		if(cardNumber.length < 13 || cardNumber.length > 16){
+			frappe.throw(__("Card Number length should be between 13 and 16 characters"));
+		}
+
+		if(expirationMonth === "00" || expirationMonth.length !== 2 || expirationYear === "0000" || expirationYear.length !== 4){
+			frappe.throw(__("Card Expiration Date is invalid"));
+		}
+
+		if(cardCode.length < 3 || cardCode.length > 4){
+			frappe.throw(__("Card Code length should be between 3 and 4 characters"));
+		}
+
+		$('#submit').prop('disabled', true);
+		$('#submit').html(__('Processing...'));
+
+		// issue credit card charge
+		await charge(card, null, async (status, err) => {
+			console.log("ON FAIL: ", status, err);
+			if ( err ) {
+				if ( !navigator.onLine || err.status === 0 ) {
+					// We lost connection or timedout
+					// Check status until network is back or timeout again
+					check_status(data, 
+						"Detected a network problem. Trying to reconnect, please wait...",
+						null, null, 0);
+				}
+			}
+
+			if ( status.status === "Fail" && status.type === "Duplicate" ) {
+				// Allow up to one more request after a duplicate with a 10 second delay.
+				setTimeout(() =>charge(card), 10000);
+			}
+		});
 	});
 
-$('#card-number').on('keydown', function () {
-	var val = $(this).val();
-	val = val.replace(/\s/g, '');
-	let newval = val;
-	if (val.match(/.{1,4}/g))
-		newval = val.match(/.{1,4}/g).join(" ");
-	$(this).val(newval);
+	// Ensures only digits are entered on digit fields
+	$('input[data-validation="digit"]')
+		.on("paste", function(e) {
+			if (e.originalEvent.clipboardData.getData('text').match(/[^\d]/))
+				e.preventDefault(); //prevent the default behaviour
+		})
+		.keypress(function(event) {
+			return (event.charCode !== 8 && event.charCode === 0 || (event.charCode >= 48 && event.charCode <= 57));
+		});
+
+	// Actively validates credit card formatting
+	$('#card-number').on('keydown', function () {
+		var val = $(this).val();
+		val = val.replace(/\s/g, '');
+		let newval = val;
+		if (val.match(/.{1,4}/g))
+			newval = val.match(/.{1,4}/g).join(" ");
+		$(this).val(newval);
+	});
+
+	// ping server first to check if this PR was already fullfilled.
+	check_status(data, "Loading...", null, async (status, err) => {
+		show_form();
+	}, 0);
 });

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -235,10 +235,6 @@ frappe.ready(function() {
 			frappe.throw(__("Card Holder Email is invalid."));
 		}
 
-		if (!validate_email(cardHolderEmail)) {
-			frappe.throw(__("Card Holder Email is invalid."));
-		}
-
 		if (!isValidCard.isPotentiallyValid) {
 			frappe.throw(__("Card Number is Invalid."));
 		}

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -113,7 +113,7 @@ frappe.ready(function() {
 
 
 	/**
-	 * Helper function, all status descitions 
+	 * Helper function, all status descriptions 
 	 * @param {ProcessStatus} status The status object sent from the backend
 	 * @param {string} label A label to display to the user during processing
 	 * @param {onCardProcessSuccess} on_success a Success function callback. 

--- a/erpnext/templates/includes/integrations/authorizenet_checkout.js
+++ b/erpnext/templates/includes/integrations/authorizenet_checkout.js
@@ -80,7 +80,7 @@ frappe.ready(function() {
 						on_fail({
 							"status": "Failed",
 							"type": "HardError",
-							"description": "Network problem! Unfortunately we could to connect with our server. If your internet is down please try again later. Otherwise, contact support to help with your transction."
+							"description": "Network problem! Unfortunately we could not connect to our server. If your internet is down please try again later. Otherwise, contact support to help with your transaction."
 						});
 						return;
 					}

--- a/erpnext/templates/pages/integrations/authorizenet_checkout.css
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.css
@@ -105,6 +105,15 @@
     padding-left: 0;
 }
 
+.authorizenet #payment-form {
+    display: none;
+}
+
+.authorizenet #please-wait {
+    text-align: center;
+}
+
+
 @media screen and (max-width: 576px) {
     .field {
         padding-left: 0;

--- a/erpnext/templates/pages/integrations/authorizenet_checkout.html
+++ b/erpnext/templates/pages/integrations/authorizenet_checkout.html
@@ -16,6 +16,10 @@
 <div class="authorizenet">
 	<div class="col-md-12">
 		<h2 class="text-center">{{ payment_context.description }}</h2>
+		<div id="please-wait">
+			Loading...
+		</div>
+
 		<form id="payment-form">
 			<div class="form-row row">
 
@@ -25,7 +29,7 @@
 							<label>{{ _("Card Holder Name") }}</label>
 						</div>
 						<div class="col-md-8 col-sm-6 pl-0 pr-0">
-							<input id="cardholder-name" name="cardholder-name" class="field w-100" placeholder="{{ _('John Doe') }}" />
+							<input id="cardholder-name" name="cardholder-name" class="field w-100" placeholder="{{ _('John Doe') }}" data-lpignore="true"/>
 						</div>
 					</div>
 
@@ -34,7 +38,7 @@
 							<label>{{ _("Email") }}</label>
 						</div>
 						<div class="col-md-8 col-sm-6 pl-0 pr-0">
-							<input id="cardholder-email" name="cardholder-email" class="field w-100" placeholder="{{ _('john@doe.com') }}" />
+							<input id="cardholder-email" name="cardholder-email" class="field w-100" placeholder="{{ _('john@doe.com') }}" data-lpignore="true"/>
 						</div>
 					</div>
 
@@ -43,7 +47,7 @@
 							<label>{{ _("Card Number") }}</label>
 						</div>
 						<div class="col-md-8 col-sm-6 p-0">
-							<input data-validation="digit" type="text" id="card-number" name="card-number" class="field" maxlength="19" placeholder="{{ _('XXXX XXXX XXXX XXXX') }}" />
+							<input data-validation="digit" type="text" id="card-number" name="card-number" class="field" maxlength="19" placeholder="{{ _('XXXX XXXX XXXX XXXX') }}"  data-lpignore="true"/>
 						</div>
 					</div>
 					<div class="group row card-details">
@@ -52,9 +56,9 @@
 						</div>
 						<div class="p-0">
 							<input data-validation="digit" type="text" id="card-expiry-month" name="card-expiry-month" class="field" maxlength="2"
-								placeholder="{{ _('MM') }}" />
+								placeholder="{{ _('MM') }}" data-lpignore="true"/>
 							<input data-validation="digit" type="text" id="card-expiry-year" name="card-expiry-year" class="field" maxlength="4"
-								placeholder="{{ _('YYYY') }}" />
+								placeholder="{{ _('YYYY') }}" data-lpignore="true"/>
 						</div>
 					</div>
 					<div class="group row card-details">
@@ -63,7 +67,7 @@
 						</div>
 						<div class="col-md-8 col-sm-6 p-0">
 							<input type="password" id="card-code" maxlength="4" name="card-code" class="field"
-								placeholder="{{ _('***') }}" />
+								placeholder="{{ _('***') }}" data-lpignore="true"/>
 						</div>
 
 					</div>

--- a/erpnext/utilities/tests/test_utils.py
+++ b/erpnext/utilities/tests/test_utils.py
@@ -1,0 +1,83 @@
+import frappe
+import unittest
+from unittest.mock import Mock
+
+from erpnext.utilities.utils import retry
+
+class TestUtils(unittest.TestCase):
+	def test_retry_success_first_call(self):
+		mockFn = Mock(return_value=True)
+
+		retry(lambda i: mockFn())
+
+		mockFn.assert_called_once()
+
+	def test_retry_fail_via_result_predicate(self):
+		mockFn = Mock()
+
+		retry(lambda i: mockFn(), 3, lambda r,i: False)
+
+		self.assertTrue(mockFn.call_count == 3, "Retry 3 times")
+
+	def test_retry_exception(self):
+		mockFn = Mock(side_effect=Exception("Unknown Error"))
+
+		retry(lambda i: mockFn(), 3)
+
+		self.assertTrue(mockFn.call_count == 3, "Retries: {} != {}".format(mockFn.call_count, 3))
+
+	def test_retry_exception_with_predicate(self):
+		mockFn = Mock(side_effect=Exception("Unknown Error"))
+		exceptionFn = Mock(return_value=False)
+
+		retry(lambda i: mockFn(), 3, None, lambda ex,i: exceptionFn())
+
+		self.assertTrue(mockFn.call_count == 3, "Retries: {} != {}".format(mockFn.call_count, 3))
+		self.assertTrue(exceptionFn.call_count == 3, "Exception Runs: {} != {}".format(exceptionFn.call_count, 3))
+
+	def test_retry_limit_via_result_predicate(self):
+		mockFn = Mock()
+
+		retry(mockFn, 3, lambda r,i: i==1)
+
+		self.assertTrue(mockFn.call_count == 2, "Retries: {} != {}".format(mockFn.call_count, 2))
+
+	def test_retry_limit_via_exception_predicate(self):
+		mockFn = Mock(side_effect=Exception("Unknown Error"))
+
+		retry(mockFn, 3, None, lambda ex, i: i==1)
+
+		self.assertTrue(mockFn.call_count == 2, "Retries: {} != {}".format(mockFn.call_count, 2))
+
+	def test_retry_result_value(self):
+		mockFn = Mock(return_value=100)
+
+		result = retry(mockFn)
+
+		mockFn.assert_called_once()
+		self.assertTrue(result == 100, "{} != 100".format(result))
+
+	def test_retry_on_result_value(self):
+		mockFn = Mock(return_value=100)
+
+		result = retry(mockFn, on_result=lambda ex,i: 200)
+
+		mockFn.assert_called_once()
+		self.assertTrue(result == 200, "{} != 200".format(result))
+
+	def test_retry_on_exception_value(self):
+		mockFn = Mock(side_effect=Exception("Unknown Error"))
+
+		result = retry(mockFn, on_exception=lambda ex,i: 200)
+
+		mockFn.assert_called_once()
+		self.assertTrue(result == 200, "{} != 200".format(result))
+
+	def test_retry_on_exception_fail_value(self):
+		mockFn = Mock(side_effect=Exception("Unknown Error"))
+
+		result = retry(mockFn, on_exception=lambda ex,i: ex)
+
+		mockFn.assert_called_once()
+		self.assertTrue(isinstance(result, Exception), "Did not return expected exception")
+

--- a/erpnext/utilities/utils.py
+++ b/erpnext/utilities/utils.py
@@ -38,3 +38,35 @@ def get_abbr(txt, max_length=2):
 
 	abbr = abbr.upper()
 	return abbr
+
+def retry(fn, retries=3, on_result=None, on_exception=None):
+	"""Retries the provided callable a certain number of times on exceptions
+	or if on_result predicate fails.
+
+	Args:
+		fn (function): Function to execute and retry
+		retries (int, optional): Number of times to retry fn. Defaults to 3.
+		on_result ([type], optional): Predicate used to test fn's result. Return true to stop retries. Defaults to None.
+		on_exception ([type], optional): Predicate used to test fn's exception. Return true to stop retries. Defaults to None.
+	"""
+	last_exception = None
+	for i in range(retries):
+		try:
+			result = fn(i)
+			if on_result:
+				result = on_result(result, i)
+				if result:
+					return result
+				else:
+					continue
+			return result
+		except Exception as ex:
+			if on_exception:
+				ex = on_exception(ex, i)
+				if ex:
+					return ex
+
+			last_exception = ex
+			continue
+		
+	return last_exception


### PR DESCRIPTION
TASK: https://app.asana.com/0/1199639423748061/1200392846186624/f

Additions:
- Adds reference_docname as refId value for authnet transaction to track order processing
- Test authorizenet for previous charges before submitting credit card
- On network drop or timeout, frontend attempts to fetch status every 5 seconds for 30 seconds before giving up
- Adds status check before loading card form to check for successful processing before taking payment again
- Status checks Integration Request for abandoned Queued request over a certain period of time before considering them failed.
- Adds lastpass data flag to prevent passwords prompts on all form fields.
- Added 10 second duplicate window guard
- Added "retry" helper method that handles running processes multiple times with on_success and on_fail predicates.
- Added unit tests for retry helper

New Loading state which checks backend for previously successful charge:
![authnet-form-load-state](https://user-images.githubusercontent.com/1656249/120383108-6f4b1d80-c2f2-11eb-9651-e4d7e70ffaac.gif)

Card decline test. Use cvv 901 to force decline:
![authnet-declined-test](https://user-images.githubusercontent.com/1656249/120383169-8b4ebf00-c2f2-11eb-8c00-3f0f0cf472e8.gif)

Success card charge after correcting a decline:
![authnet-charge-after-decline](https://user-images.githubusercontent.com/1656249/120383232-a3264300-c2f2-11eb-81e9-5dc805b683c9.gif)

Issue card processing and force offline error. Watch console retry 3 times before browser goes back online and succeeding:
![authnet-survive-disconnect](https://user-images.githubusercontent.com/1656249/120383349-c4872f00-c2f2-11eb-8658-ae78512b4891.gif)

Submit valid card for processing and user presses reload button . Watch for pre state check complete and forward user after the refresh:
![authnet-survive-refresh-during-charge](https://user-images.githubusercontent.com/1656249/120383465-e680b180-c2f2-11eb-89c4-f71e811fb1e6.gif)
