### PR TITLE
chore: Removed the function of create material req. for frappe confirm dialog where condition prompts NO

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -120,9 +120,6 @@ frappe.ui.form.on('Production Plan', {
 		frappe.confirm(__("Do you want to submit the material request"),
 			function() {
 				frm.events.create_material_request(frm, 1);
-			},
-			function() {
-				frm.events.create_material_request(frm, 0);
 			}
 		);
 	},


### PR DESCRIPTION
Title: In Production Plan, New Material Request is getting created with/out Pop Up.

Fix Description: When the user clicks on the "NO" option at the popup window or outside the popup window, the system is not creating the Material request, unless clicks on the "YES" option.

Asana Task: https://app.asana.com/0/1200073273462988/1200035083056715/f

Fix gif is attached below : -
**(Note : Himanshu's fix need to be added with this fix in bs-may-sprint-2 => https://github.com/Bloomstack/frappe/pull/577/files)**

https://user-images.githubusercontent.com/80836439/120464353-73427280-c3ba-11eb-985a-f1e7e9c1cc52.mp4

