### PR TITLE
fix: applied filter for batch_no, batch_qty > 0 in product recall

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -246,7 +246,7 @@ def set_batch_nos(doc, warehouse_field, throw=False):
 			else:
 				batch_qty = get_batch_qty(batch_no=d.batch_no, warehouse=warehouse)
 				if flt(batch_qty, d.precision("qty")) < flt(qty, d.precision("qty")):
-					frappe.throw(_("Row #{0}: The batch {1} has only {2} qty. Please select another batch which has {3} qty available or split the row into multiple rows, to deliver/issue from multiple batches").format(d.idx, d.batch_no, batch_qty, qty))
+					frappe.throw(_("Row #{0}: The <b>Batch {1}</b> has only <b>{2} qty</b> in <b>{3}</b>. Please select another batch which has {4} qty available or split the row into multiple rows, to deliver/issue from multiple batches").format(d.idx, get_link_to_form("Batch", d.batch_no), batch_qty, warehouse, qty))
 
 @frappe.whitelist()
 def get_batch_no(item_code, warehouse, qty=1, throw=False, serial_no=None):

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -246,7 +246,7 @@ def set_batch_nos(doc, warehouse_field, throw=False):
 			else:
 				batch_qty = get_batch_qty(batch_no=d.batch_no, warehouse=warehouse)
 				if flt(batch_qty, d.precision("qty")) < flt(qty, d.precision("qty")):
-					frappe.throw(_("Row #{0}: The <b>Batch {1}</b> has only <b>{2} qty</b> in <b>{3}</b>. Please select another batch which has {4} qty available or split the row into multiple rows, to deliver/issue from multiple batches").format(d.idx, get_link_to_form("Batch", d.batch_no), batch_qty, warehouse, qty))
+					frappe.throw(_("Row #{0}: The <b>Batch {1}</b> has only <b>{2} qty</b> in  Warehouse <b>{3}</b>. Please select another batch which has {4} qty available or split the row into multiple rows, to deliver/issue from multiple batches").format(d.idx, get_link_to_form("Batch", d.batch_no), batch_qty, warehouse, qty))
 
 @frappe.whitelist()
 def get_batch_no(item_code, warehouse, qty=1, throw=False, serial_no=None):

--- a/erpnext/stock/doctype/product_recall/product_recall.js
+++ b/erpnext/stock/doctype/product_recall/product_recall.js
@@ -5,4 +5,13 @@ frappe.ui.form.on('Product Recall', {
 	// refresh: function(frm) {
 
 	// }
+	onload: function(frm) {
+		frm.set_query('batch_no', function(doc) {
+			return {
+				filters: {
+					"batch_qty": [">", 0]
+				}
+			};
+		});
+	},
 });


### PR DESCRIPTION
Ref: [Asana](https://app.asana.com/0/1192407896547052/1200426337727458)
Ref: [Asana](https://app.asana.com/0/1192407896547052/1200426337727452)

lInk to batch document and show warehouse in the error message
![screenshot-bloomstack_demo_8000-2021 06 08-11_35_15](https://user-images.githubusercontent.com/53251406/121136742-9a35f400-c853-11eb-9172-c0e63bdf78f0.jpg)
