### PR TITLE
fix: Only items to be manufactured is fetched in Production plan item while creating Production Plan from Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1123,6 +1123,7 @@ def make_production_plan(source_name, target_doc=None):
 			'postprocess': update_item_data
 		}
 	}, target_doc, set_missing_values)
+	doc.run_method("get_items")
 	return doc
 
 @frappe.whitelist()


### PR DESCRIPTION
Ref: [Asana](https://app.asana.com/0/1192407896547052/1199912935350759)
![screencast-jhaudio_8008-2021 06 14-10_04_55](https://user-images.githubusercontent.com/53251406/121839642-3189c400-ccf8-11eb-882a-c588c0f837f5.gif)
