### PR TITLE
fix: validate batch number for stock items in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -692,24 +692,19 @@ class StockEntry(StockController):
 		self.make_sl_entries(sl_entries, self.amended_from and 'Yes' or 'No')
 
 	def validate_mandatory_batch_number(self):
-		"""validate the stock items batch number is present or not"""
+		"""
+			validate the stock items batch number is present or not
+		"""
 		items_without_batch_no = []
-		MANDATE_MSG = 'Batch number is mandatory for Item at : <br><b>'
-		item_list = self.get("items")		
-		# iterate through all row of stock entry item and check whether batch no for the item is present or not by querying to tabItem table
-		for index in range(len(item_list)):
-			item_code = self.items[index].item_code
-			item_lists_details = frappe.db.sql("""select name, item_name, has_batch_no, docstatus,
-			is_stock_item, has_variants, stock_uom, create_new_batch
-			from tabItem where name=%s""", item_code, as_dict=True)
-			batch_number = item_list[index].batch_no
+
+		for idx, item in enumerate(self.get("items")):
+			_item = frappe.get_doc("Item", item.item_code)
 			# validate the Has Batch No from Item doc was mark checked or not
-			if (not batch_number and item_lists_details[0].has_batch_no ==1):
-				row_id = 'Row '+str(item_list[index].idx)
-				items_without_batch_no.append(row_id)
-			
+			if not item.batch_no and _item.has_batch_no:
+				items_without_batch_no.append('Row ' + str(idx))
+
 		if items_without_batch_no:
-			frappe.throw('Batch number is mandatory for Item at : <br><b>' + ', '.join(items_without_batch_no))
+			frappe.throw(_('Batch number is mandatory for Item at : <br><b>' + ', '.join(items_without_batch_no)))
 
 	def update_batch_with_customer_provided_item(self):
 		# update batch doc with provided by customer

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -708,7 +708,7 @@ class StockEntry(StockController):
 				row_id = 'Row '+str(item_list[index].idx)
 				items_without_batch_no.append(row_id)
 			
-		if (items_without_batch_no):
+		if items_without_batch_no:
 			frappe.throw('Batch number is mandatory for Item at : <br><b>' + ', '.join(items_without_batch_no))
 
 	def update_batch_with_customer_provided_item(self):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -692,18 +692,19 @@ class StockEntry(StockController):
 		self.make_sl_entries(sl_entries, self.amended_from and 'Yes' or 'No')
 
 	def validate_mandatory_batch_number(self):
-		# to validate the stock items batch number is present or not
+		"""validate the stock items batch number is present or not"""
 		items_without_batch_no = []
 		MANDATE_MSG = 'Batch number is mandatory for Item at : <br><b>'
-		item_list = self.get("items")
-		
+		item_list = self.get("items")		
+		# iterate through all row of stock entry item and check whether batch no for the item is present or not by querying to tabItem table
 		for index in range(len(item_list)):
-			item_code_list = self.items[index].item_code
+			item_code = self.items[index].item_code
 			item_lists_details = frappe.db.sql("""select name, item_name, has_batch_no, docstatus,
 			is_stock_item, has_variants, stock_uom, create_new_batch
-			from tabItem where name=%s""", item_code_list, as_dict=True)
+			from tabItem where name=%s""", item_code, as_dict=True)
 			batch_number = item_list[index].batch_no
-			if (batch_number == None and item_lists_details[0].has_batch_no ==1):
+			# validate the Has Batch No from Item doc was mark checked or not
+			if (not batch_number and item_lists_details[0].has_batch_no ==1):
 				row_id = 'Row '+str(item_list[index].idx)
 				items_without_batch_no.append(row_id)
 			

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -709,7 +709,7 @@ class StockEntry(StockController):
 				items_without_batch_no.append(row_id)
 			
 		if (items_without_batch_no):
-			frappe.throw(MANDATE_MSG +', '.join(items_without_batch_no))
+			frappe.throw('Batch number is mandatory for Item at : <br><b>' + ', '.join(items_without_batch_no))
 
 	def update_batch_with_customer_provided_item(self):
 		# update batch doc with provided by customer


### PR DESCRIPTION
Title: Final stock entry message Improvement.

Fix Description: The system shows all validations for the batch in one go rather than line by line for stock items, which has batch number.

Asana Task: https://app.asana.com/0/1200073273462988/1199966800575045

Before Functionality was throwing error messages for Stock Items, one by one. Below is the gif attached:-


https://user-images.githubusercontent.com/80836439/122925885-e66d5200-d384-11eb-84ee-4a103cc42731.mp4

After the fix, it throws the error message iterating through all rows at once. Below is the gif attached:-

https://user-images.githubusercontent.com/80836439/122925928-f2591400-d384-11eb-992b-a5e8cb010d8b.mp4

