### PR TITLE
chore: added custom delivery_settings fields into core from bloomstack_core

### DIFF
--- a/erpnext/stock/doctype/delivery_settings/delivery_settings.json
+++ b/erpnext/stock/doctype/delivery_settings/delivery_settings.json
@@ -16,7 +16,7 @@
   "stop_delay",
   "delivery_window",
   "delivery_start_time",
-  "send_warnings_for_deliveries_outside_the_window",
+  "send_delivery_window_warning",
   "column_break_9",
   "delivery_end_time"
  ],
@@ -102,13 +102,13 @@
   {
    "default": "0",
    "description": "If an order is set to be delivered outside the global or customer's delivery window, then send out an email to the Fulfillment and Accounts Managers\n",
-   "fieldname": "send_warnings_for_deliveries_outside_the_window",
+   "fieldname": "send_delivery_window_warning",
    "fieldtype": "Check",
    "label": "Send Warnings for Deliveries Outside the Window"
   }
  ],
  "issingle": 1,
- "modified": "2021-08-31 13:38:32.437635",
+ "modified": "2021-08-31 23:55:13.290755",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Settings",

--- a/erpnext/stock/doctype/delivery_settings/delivery_settings.json
+++ b/erpnext/stock/doctype/delivery_settings/delivery_settings.json
@@ -4,6 +4,9 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "delivery_defaults_section",
+  "packing_warehouse",
+  "default_activity_type",
   "sb_dispatch",
   "dispatch_template",
   "dispatch_attachment",
@@ -13,6 +16,7 @@
   "stop_delay",
   "delivery_window",
   "delivery_start_time",
+  "send_warnings_for_deliveries_outside_the_window",
   "column_break_9",
   "delivery_end_time"
  ],
@@ -77,10 +81,34 @@
    "fieldtype": "Link",
    "label": "Default Fulfilment Partner",
    "options": "Fulfillment Partner"
+  },
+  {
+   "fieldname": "delivery_defaults_section",
+   "fieldtype": "Section Break",
+   "label": "Delivery Defaults"
+  },
+  {
+   "fieldname": "packing_warehouse",
+   "fieldtype": "Link",
+   "label": "Packing Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "default_activity_type",
+   "fieldtype": "Link",
+   "label": "Default Activity Type",
+   "options": "Activity Type"
+  },
+  {
+   "default": "0",
+   "description": "If an order is set to be delivered outside the global or customer's delivery window, then send out an email to the Fulfillment and Accounts Managers\n",
+   "fieldname": "send_warnings_for_deliveries_outside_the_window",
+   "fieldtype": "Check",
+   "label": "Send Warnings for Deliveries Outside the Window"
   }
  ],
  "issingle": 1,
- "modified": "2021-04-20 08:58:55.716956",
+ "modified": "2021-08-31 13:38:32.437635",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Settings",

--- a/erpnext/stock/doctype/delivery_settings/delivery_settings.json
+++ b/erpnext/stock/doctype/delivery_settings/delivery_settings.json
@@ -4,7 +4,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "delivery_defaults_section",
+  "delivery_defaults",
   "packing_warehouse",
   "default_activity_type",
   "sb_dispatch",
@@ -83,11 +83,6 @@
    "options": "Fulfillment Partner"
   },
   {
-   "fieldname": "delivery_defaults_section",
-   "fieldtype": "Section Break",
-   "label": "Delivery Defaults"
-  },
-  {
    "fieldname": "packing_warehouse",
    "fieldtype": "Link",
    "label": "Packing Warehouse",
@@ -105,10 +100,15 @@
    "fieldname": "send_delivery_window_warning",
    "fieldtype": "Check",
    "label": "Send Warnings for Deliveries Outside the Window"
+  },
+  {
+   "fieldname": "delivery_defaults",
+   "fieldtype": "Section Break",
+   "label": "Delivery Defaults"
   }
  ],
  "issingle": 1,
- "modified": "2021-08-31 23:55:13.290755",
+ "modified": "2021-09-01 07:28:19.463582",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Settings",


### PR DESCRIPTION
Task link: https://bloomstack.com/desk#Form/Task/TASK-2021-00247

Bloomstack Core link : https://github.com/Bloomstack/bloomstack_core/pull/630

**Before :**
![Delivery_Settings_before](https://user-images.githubusercontent.com/80836439/131573306-c0c92258-522b-4503-8e31-aa5510c9b69f.png)

**After :**
![Delivery_Settings_after](https://user-images.githubusercontent.com/80836439/131626465-da2d0c3c-067e-4c4b-85c1-57e411ded511.PNG)
