### PR TITLE
chore: add Licence field in Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -23,6 +23,7 @@
   "set_posting_time",
   "due_date",
   "amended_from",
+  "license",
   "returns",
   "return_against",
   "column_break_21",
@@ -1611,12 +1612,18 @@
    "fieldname": "email_coas",
    "fieldtype": "Button",
    "label": "Email Certificates of Analysis"
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Link",
+   "label": "License",
+   "options": "Compliance Info"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2021-07-16 04:10:36.433956",
+ "modified": "2021-09-01 01:38:51.022351",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Task link: https://bloomstack.com/desk#Form/Task/TASK-2021-00250
Bloomstack Core PR: https://github.com/Bloomstack/bloomstack_core/pull/636

Added Licence field in   sales_invoice.json file.

Before:
![image](https://user-images.githubusercontent.com/86222064/131658636-cb0e0404-dab0-471f-82e9-54e71e952ec9.png)


After:
![image](https://user-images.githubusercontent.com/86222064/131658690-b757e30e-0625-4a69-ad3a-e7cdcc600708.png)
