### PR TITLE
chore: move pick_list_item custom fields from bloomstack_core to core

### DIFF
--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -30,7 +30,9 @@
   "sales_order",
   "sales_order_item",
   "material_request",
-  "material_request_item"
+  "material_request_item",
+  "cb_reference",
+  "so_customer"
  ],
  "fields": [
   {
@@ -200,10 +202,23 @@
    "label": "COA Batch",
    "options": "Batch",
    "read_only": 1
+  },
+  {
+   "fieldname": "cb_reference",
+   "fieldtype": "Column Break",
+   "label": "Pick List Item-cb_reference"
+  },
+  {
+   "fetch_from": "sales_order.customer",
+   "fieldname": "so_customer",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "SO Customer",
+   "read_only": 1
   }
  ],
  "istable": 1,
- "modified": "2021-01-06 04:50:21.095201",
+ "modified": "2021-09-01 23:59:04.628247",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",

--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -205,8 +205,7 @@
   },
   {
    "fieldname": "cb_reference",
-   "fieldtype": "Column Break",
-   "label": "Pick List Item-cb_reference"
+   "fieldtype": "Column Break"
   },
   {
    "fetch_from": "sales_order.customer",


### PR DESCRIPTION
Task link:  https://bloomstack.com/desk#Form/Task/TASK-2021-00250
Bloomstack core pr: https://github.com/Bloomstack/bloomstack_core/pull/643

Made necessary changes in following fields.
1.Pick List Item-cb_reference
2.SO Customer

Please refer the screenshot.
![image](https://user-images.githubusercontent.com/86222064/131819883-72fac949-6646-42b8-8e7d-97c5a2cf486b.png)
