### PR TITLE
fix: move purchase invoice custom fields to erpnext from bloomstack-core

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -1311,6 +1311,7 @@
    "options": "Compliance Info"
   },
   {
+   "depends_on": "eval:doc.docstatus==0",
    "fieldname": "reverse_calculate",
    "fieldtype": "Button",
    "label": "Reverse Calculate"

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -24,6 +24,7 @@
   "posting_time",
   "set_posting_time",
   "amended_from",
+  "license",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
@@ -73,6 +74,7 @@
   "column_break_28",
   "total_net_weight",
   "total",
+  "reverse_calculate",
   "net_total",
   "taxes_section",
   "tax_category",
@@ -1301,12 +1303,23 @@
    "fieldname": "use_tax_amount",
    "fieldtype": "Currency",
    "label": "Use Tax Amount"
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Link",
+   "label": "License",
+   "options": "Compliance Info"
+  },
+  {
+   "fieldname": "reverse_calculate",
+   "fieldtype": "Button",
+   "label": "Reverse Calculate"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 204,
  "is_submittable": 1,
- "modified": "2021-01-19 03:12:20.087537",
+ "modified": "2021-09-02 03:05:09.515073",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",


### PR DESCRIPTION
move purchase invoice custom fields to erpnext from bloomstack-core
https://bloomstack.com/desk#Form/Task/TASK-2021-00251
https://github.com/Bloomstack/bloomstack_core/pull/645
Before:
![image](https://user-images.githubusercontent.com/12559147/131827913-a543dc5f-e7d0-4f86-a740-5cf39caeb5fd.png)
![image](https://user-images.githubusercontent.com/12559147/131828117-ab6df5fb-4cb3-4587-a870-726d1e596076.png)

After:
![image](https://user-images.githubusercontent.com/12559147/131828202-6139b748-f718-4f11-8c8b-35830e58d345.png)
![image](https://user-images.githubusercontent.com/12559147/131828267-75d425fb-fd8e-4a23-8c82-abeeb4b2be7e.png)

