### PR TITLE
fix: move work order custom fields to erpnext from bloomstack-core

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -13,6 +13,7 @@
   "item_name",
   "image",
   "bom_no",
+  "title",
   "manufacturing_type",
   "column_break1",
   "company",
@@ -506,13 +507,18 @@
    "fieldname": "skip_raw_material_validation",
    "fieldtype": "Check",
    "label": "Skip Raw Material Validation"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title"
   }
  ],
  "icon": "fa fa-cogs",
  "idx": 1,
  "image_field": "image",
  "is_submittable": 1,
- "modified": "2021-02-16 04:30:47.312630",
+ "modified": "2021-09-02 05:13:56.796454",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",


### PR DESCRIPTION
move work order custom fields to erpnext from bloomstack-core
https://bloomstack.com/desk#Form/Task/TASK-2021-00251
[Dependent Bloomstack Core PR](https://github.com/Bloomstack/bloomstack_core/pull/652)
fix: move work order custom fields to erpnext from bloomstack-core
Before:
![image](https://user-images.githubusercontent.com/12559147/131842345-db6cdc80-75c5-4736-9463-6050f4784047.png)
After
![image](https://user-images.githubusercontent.com/12559147/131842363-f0a6c705-bbbe-4904-87a9-9e6e2fbc00f4.png)
