### PR TITLE
chore: added fields to purchase_receipt.json file

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -21,6 +21,7 @@
   "company",
   "is_return",
   "return_against",
+  "license",
   "section_addresses",
   "supplier_address",
   "contact_person",
@@ -61,6 +62,7 @@
   "column_break_27",
   "total_net_weight",
   "total",
+  "reverse_calculate",
   "net_total",
   "taxes_charges_section",
   "tax_category",
@@ -96,6 +98,9 @@
   "rounded_total",
   "in_words",
   "disable_rounded_total",
+  "payment_terms_section",
+  "payment_terms_template",
+  "payment_schedule",
   "terms_section_break",
   "tc_name",
   "terms",
@@ -1066,12 +1071,42 @@
    "hidden": 1,
    "label": "Batch No",
    "print_hide": 1
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Link",
+   "label": "License",
+   "options": "Compliance Info"
+  },
+  {
+   "depends_on": "doc.docstatus==0;",
+   "fieldname": "reverse_calculate",
+   "fieldtype": "Button",
+   "label": "Reverse Calculate"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "payment_terms_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Terms"
+  },
+  {
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template"
+  },
+  {
+   "fieldname": "payment_schedule",
+   "fieldtype": "Table",
+   "label": "Payment Schedule",
+   "options": "Payment Schedule"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
- "modified": "2020-12-23 04:49:34.611219",
+ "modified": "2021-09-06 04:11:28.144054",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",


### PR DESCRIPTION
Added fields to erpnext from Bloomstack core for file purchase_receipt.json.
Task details: bloomstack_core/bloomstack_core/custom/purchase_receipt.json

Bcore PR:  https://github.com/Bloomstack/bloomstack_core/pull/660

Before:
![image](https://user-images.githubusercontent.com/86222064/132223876-90f0ebba-286d-4c18-a480-1eb392984e07.png)
--------------------------------------
![image](https://user-images.githubusercontent.com/86222064/132223917-53a84198-ae92-4269-86d8-e7fecd9460d7.png)
--------------------------------------
![image](https://user-images.githubusercontent.com/86222064/132223979-c11c4a5c-7cbe-4991-8257-1e5fa1e14e3e.png)


After:
![image](https://user-images.githubusercontent.com/86222064/132224316-5e4232fc-7386-461f-8f22-aeb5c9fe338c.png)

--------------------------------------
![image](https://user-images.githubusercontent.com/86222064/132224353-ace42eb6-ae9b-43cd-8e46-9b6c125bb6cf.png)

-------------------------------------
![image](https://user-images.githubusercontent.com/86222064/132224389-aa27b81f-19a1-4325-8074-d35194cd4586.png)
