### PR TITLE
chore: move Purchase Receipt custom fields from bloomstack_core to erpnext

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -21,6 +21,7 @@
   "company",
   "is_return",
   "return_against",
+  "license",
   "section_addresses",
   "supplier_address",
   "contact_person",
@@ -61,6 +62,7 @@
   "column_break_27",
   "total_net_weight",
   "total",
+  "reverse_calculate",
   "net_total",
   "taxes_charges_section",
   "tax_category",
@@ -96,6 +98,9 @@
   "rounded_total",
   "in_words",
   "disable_rounded_total",
+  "payment_terms",
+  "payment_terms_template",
+  "payment_schedule",
   "terms_section_break",
   "tc_name",
   "terms",
@@ -1066,12 +1071,42 @@
    "hidden": 1,
    "label": "Batch No",
    "print_hide": 1
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Link",
+   "label": "License",
+   "options": "Compliance Info"
+  },
+  {
+   "depends_on": "doc.docstatus==0;",
+   "fieldname": "reverse_calculate",
+   "fieldtype": "Button",
+   "label": "Reverse Calculate"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "payment_terms",
+   "fieldtype": "Section Break",
+   "label": "Payment Terms"
+  },
+  {
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template"
+  },
+  {
+   "fieldname": "payment_schedule",
+   "fieldtype": "Table",
+   "label": "Payment Schedule",
+   "options": "Payment Schedule"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
- "modified": "2020-12-23 04:49:34.611219",
+ "modified": "2021-09-06 20:55:00.706461",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",


### PR DESCRIPTION
Updated the PR according to the suggstions.

task link: https://bloomstack.com/desk#Form/Task/TASK-2021-00250

bcore updated pr:  https://github.com/Bloomstack/bloomstack_core/pull/662

![image](https://user-images.githubusercontent.com/86222064/132297370-77c7950e-96ae-49d9-9c63-b4db3b89fb73.png)
