### PR TITLE
chore: move custom fields of Supplier from bloomstack_core to erpnext

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -15,6 +15,7 @@
   "country",
   "default_bank_account",
   "tax_id",
+  "irs_1099",
   "tax_category",
   "tax_withholding_category",
   "is_transporter",
@@ -45,6 +46,8 @@
   "on_hold",
   "hold_type",
   "release_date",
+  "licenses_sb",
+  "licenses",
   "address_contacts",
   "address_html",
   "column_break1",
@@ -378,12 +381,29 @@
    "fieldname": "allow_purchase_invoice_creation_without_purchase_receipt",
    "fieldtype": "Check",
    "label": "Allow Purchase Invoice Creation Without Purchase Receipt"
+  },
+  {
+   "default": "0",
+   "fieldname": "irs_1099",
+   "fieldtype": "Check",
+   "label": "Is IRS 1099 reporting required for supplier?"
+  },
+  {
+   "fieldname": "licenses_sb",
+   "fieldtype": "Section Break",
+   "label": "Licenses"
+  },
+  {
+   "fieldname": "licenses",
+   "fieldtype": "Table",
+   "label": "Licenses",
+   "options": "Compliance License Detail"
   }
  ],
  "icon": "fa fa-user",
  "idx": 370,
  "image_field": "image",
- "modified": "2021-01-14 00:01:23.391267",
+ "modified": "2021-09-07 00:13:20.469752",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",


### PR DESCRIPTION
Added fields from bloomstack core to erpnext supplier.json file

Task details: https://bloomstack.com/desk#Form/Task/TASK-2021-00250
bcore pr:  https://github.com/Bloomstack/bloomstack_core/pull/666

Before:

![image](https://user-images.githubusercontent.com/86222064/132319593-146625ab-4eec-4ee4-9325-5a90f8044eb2.png)
------------------------
![image](https://user-images.githubusercontent.com/86222064/132319616-5e63b4ac-61eb-4a04-8ad6-25c94cf2eb66.png)


After:

![image](https://user-images.githubusercontent.com/86222064/132319642-c46d4e2d-d107-4872-9871-d54336852903.png)
