### PR TITLE
chore: move api_request_log doctype from bloomstack_Core to erpnext

### DIFF
--- a/erpnext/compliance/doctype/api_request_log/api_request_log.js
+++ b/erpnext/compliance/doctype/api_request_log/api_request_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('API Request Log', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/compliance/doctype/api_request_log/api_request_log.json
+++ b/erpnext/compliance/doctype/api_request_log/api_request_log.json
@@ -1,0 +1,97 @@
+{
+ "creation": "2018-07-23 02:03:13.087015",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "type",
+  "endpoint",
+  "request_body",
+  "response_code",
+  "response_body",
+  "retry",
+  "reference_doctype",
+  "reference_document"
+ ],
+ "fields": [
+  {
+   "default": "METRC",
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "METRC\nBioTrackTHC",
+   "read_only": 1
+  },
+  {
+   "fieldname": "endpoint",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Endpoint",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "request_body",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Request Body",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "response_code",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Response Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "response_body",
+   "fieldtype": "Code",
+   "label": "Response Body",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.response_code != 200",
+   "fieldname": "retry",
+   "fieldtype": "Button",
+   "label": "Retry",
+   "options": "retry"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference DocType",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_document",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Document",
+   "options": "reference_doctype",
+   "read_only": 1
+  }
+ ],
+ "modified": "2021-09-14 04:44:00.073364",
+ "modified_by": "Administrator",
+ "module": "Compliance",
+ "name": "API Request Log",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/erpnext/compliance/doctype/api_request_log/api_request_log.py
+++ b/erpnext/compliance/doctype/api_request_log/api_request_log.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class APIRequestLog(Document):
+	pass

--- a/erpnext/compliance/doctype/api_request_log/test_api_request_log.py
+++ b/erpnext/compliance/doctype/api_request_log/test_api_request_log.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestAPIRequestLog(unittest.TestCase):
+	pass


### PR DESCRIPTION
feat: move api_request_log doctype from bloomstack_Core to erpnext
https://bloomstack.com/desk#Form/Task/TASK-2021-00272
https://github.com/Bloomstack/bloomstack_core/pull/702