### PR TITLE
feat: add new doctype Bloomtrace Settings

### DIFF
--- a/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.js
+++ b/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Bloomtrace Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.json
+++ b/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.json
@@ -1,0 +1,68 @@
+{
+ "creation": "2021-09-27 02:43:57.409604",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "site_url",
+  "customer_name",
+  "company_name",
+  "license",
+  "environment",
+  "bloomtrace_url"
+ ],
+ "fields": [
+  {
+   "fieldname": "site_url",
+   "fieldtype": "Data",
+   "label": "Site URL"
+  },
+  {
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "label": "Customer Name"
+  },
+  {
+   "fieldname": "company_name",
+   "fieldtype": "Data",
+   "label": "Company Name"
+  },
+  {
+   "fieldname": "license",
+   "fieldtype": "Data",
+   "label": "License"
+  },
+  {
+   "fieldname": "environment",
+   "fieldtype": "Data",
+   "label": "Environment"
+  },
+  {
+   "fieldname": "bloomtrace_url",
+   "fieldtype": "Data",
+   "label": "Bloomtrace URL"
+  }
+ ],
+ "issingle": 1,
+ "modified": "2021-09-27 02:43:57.409604",
+ "modified_by": "Administrator",
+ "module": "Setup",
+ "name": "Bloomtrace Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.py
+++ b/erpnext/setup/doctype/bloomtrace_settings/bloomtrace_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class BloomtraceSettings(Document):
+	pass

--- a/erpnext/setup/doctype/bloomtrace_settings/test_bloomtrace_settings.py
+++ b/erpnext/setup/doctype/bloomtrace_settings/test_bloomtrace_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestBloomtraceSettings(unittest.TestCase):
+	pass


### PR DESCRIPTION
**TODO**
- [x] Create Doctype
- [x] Add fields to the Doctype
- [x] Test Doctype

**Bloomtrace Settings:**
 Add new Doctype name Bloomtrace Settings
Description: Create a new doctype"Bloomtrace Settings" in the setup module which will store the configurable details for the Bloomtrace platform.

**Screenshot:**
<img width="1667" alt="Screenshot 2021-09-27 at 4 04 11 PM" src="https://user-images.githubusercontent.com/77478531/134893027-b64e4936-8efc-4a9c-9105-2da9c08ef630.png">




