### PR TITLE
fix: test for sales order, pick list and sales invoice

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -96,7 +96,7 @@ class TestAccountingDimension(unittest.TestCase):
 		})
 
 		si.save()
-		self.assertRaises(frappe.ValidationError, si.submit)
+		self.assertRaises(frappe.ValidationError, si.submit())
 
 	def tearDown(self):
 		disable_dimension()

--- a/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
+++ b/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
@@ -207,7 +207,7 @@ class TestInvoiceDiscounting(unittest.TestCase):
 
 	def test_make_payment_before_loan_period(self):
 		#it has problem
-		inv = create_sales_invoice(rate=700)
+		inv = create_sales_invoice(item_code="_Test Item Home Desktop 100",rate=700)
 		inv_disc = create_invoice_discounting([inv.name],
 				accounts_receivable_credit=self.ar_credit,
 				accounts_receivable_discounted=self.ar_discounted,
@@ -238,7 +238,7 @@ class TestInvoiceDiscounting(unittest.TestCase):
 
 	def test_make_payment_before_after_period(self):
 		#it has problem
-		inv = create_sales_invoice(rate=700)
+		inv = create_sales_invoice(item_code="_Test Item Home Desktop 100",rate=700)
 		inv_disc = create_invoice_discounting([inv.name],
 				accounts_receivable_credit=self.ar_credit,
 				accounts_receivable_discounted=self.ar_discounted,

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -197,7 +197,7 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(si.grand_total, 32.55)
 
 	def test_sales_invoice_with_discount_and_inclusive_tax(self):
-		si = create_sales_invoice(qty=100, rate=50, do_not_save=True)
+		si = create_sales_invoice(item_code="_Test Item Home Desktop 100", qty=100, rate=50, do_not_save=True)
 		si.append("taxes", {
 			"charge_type": "On Net Total",
 			"account_head": "_Test Account Service Tax - _TC",
@@ -1034,14 +1034,14 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(si.get("items")[0].serial_no, dn.get("items")[0].serial_no)
 
 	def test_return_sales_invoice(self):
-		make_stock_entry(item_code="_Test Item", target="Stores - TCP1", qty=50, basic_rate=100)
+		make_stock_entry(item_code="_Test Item Home Desktop 100", target="Stores - TCP1", qty=50, basic_rate=100)
 
-		actual_qty_0 = get_qty_after_transaction(item_code = "_Test Item", warehouse = "Stores - TCP1")
+		actual_qty_0 = get_qty_after_transaction(item_code = "_Test Item Home Desktop 100", warehouse = "Stores - TCP1")
 
-		si = create_sales_invoice(qty = 5, rate=500, update_stock=1, company= "_Test Company with perpetual inventory", debit_to="Debtors - TCP1", item_code= "_Test Item", warehouse="Stores - TCP1", income_account = "Sales - TCP1", expense_account = "Cost of Goods Sold - TCP1", cost_center = "Main - TCP1")
+		si = create_sales_invoice(qty = 5, rate=500, update_stock=1, company= "_Test Company with perpetual inventory", debit_to="Debtors - TCP1", item_code= "_Test Item Home Desktop 100", warehouse="Stores - TCP1", income_account = "Sales - TCP1", expense_account = "Cost of Goods Sold - TCP1", cost_center = "Main - TCP1")
 
 
-		actual_qty_1 = get_qty_after_transaction(item_code = "_Test Item", warehouse = "Stores - TCP1")
+		actual_qty_1 = get_qty_after_transaction(item_code = "_Test Item Home Desktop 100", warehouse = "Stores - TCP1")
 
 		frappe.db.commit()
 
@@ -1052,9 +1052,9 @@ class TestSalesInvoice(unittest.TestCase):
 			"voucher_no": si.name}, "stock_value_difference") / 5
 
 		# return entry
-		si1 = create_sales_invoice(is_return=1, return_against=si.name, qty=-2, rate=500, update_stock=1, company= "_Test Company with perpetual inventory", debit_to="Debtors - TCP1", item_code= "_Test Item", warehouse="Stores - TCP1", income_account = "Sales - TCP1", expense_account = "Cost of Goods Sold - TCP1", cost_center = "Main - TCP1")
+		si1 = create_sales_invoice(is_return=1, return_against=si.name, qty=-2, rate=500, update_stock=1, company= "_Test Company with perpetual inventory", debit_to="Debtors - TCP1", item_code= "_Test Item Home Desktop 100", warehouse="Stores - TCP1", income_account = "Sales - TCP1", expense_account = "Cost of Goods Sold - TCP1", cost_center = "Main - TCP1")
 
-		actual_qty_2 = get_qty_after_transaction(item_code = "_Test Item", warehouse = "Stores - TCP1")
+		actual_qty_2 = get_qty_after_transaction(item_code = "_Test Item Home Desktop 100", warehouse = "Stores - TCP1")
 		self.assertEqual(actual_qty_1 + 2, actual_qty_2)
 
 		incoming_rate, stock_value_difference = frappe.db.get_value("Stock Ledger Entry",
@@ -1208,7 +1208,7 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertRaises(InvalidAccountCurrency, si5.submit)
 
 	def test_create_so_with_margin(self):
-		si = create_sales_invoice(item_code="_Test Item", qty=1, do_not_submit=True)
+		si = create_sales_invoice(item_code="_Test Item Home Desktop 100", qty=1, do_not_submit=True)
 		price_list_rate = 100
 		si.items[0].price_list_rate = price_list_rate
 		si.items[0].margin_type = 'Percentage'
@@ -1460,10 +1460,10 @@ class TestSalesInvoice(unittest.TestCase):
 			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
 	def test_rounding_adjustment_2(self):
-		si = create_sales_invoice(rate=400, do_not_save=True)
+		si = create_sales_invoice(item_code="_Test Item Home Desktop 100", rate=400, do_not_save=True)
 		for rate in [400, 600, 100]:
 			si.append("items", {
-				"item_code": "_Test Item",
+				"item_code": "_Test Item Home Desktop 100",
 				"gst_hsn_code": "999800",
 				"warehouse": "_Test Warehouse - _TC",
 				"qty": 1,
@@ -1584,7 +1584,7 @@ class TestSalesInvoice(unittest.TestCase):
 		cost_center = "_Test Cost Center for BS Account - _TC"
 		create_cost_center(cost_center_name="_Test Cost Center for BS Account", company="_Test Company")
 
-		si =  create_sales_invoice_against_cost_center(cost_center=cost_center, debit_to="Debtors - _TC")
+		si =  create_sales_invoice_against_cost_center(item_code="_Test Item Home Desktop 100", cost_center=cost_center, debit_to="Debtors - _TC")
 		self.assertEqual(si.cost_center, cost_center)
 
 		expected_values = {
@@ -1614,7 +1614,7 @@ class TestSalesInvoice(unittest.TestCase):
 		accounts_settings.allow_cost_center_in_entry_of_bs_account = 1
 		accounts_settings.save()
 		cost_center = "_Test Cost Center - _TC"
-		si =  create_sales_invoice(debit_to="Debtors - _TC")
+		si =  create_sales_invoice(item_code="_Test Item Home Desktop 100", debit_to="Debtors - _TC")
 
 		expected_values = {
 			"Debtors - _TC": {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -564,7 +564,8 @@ def get_subitems(doc, data, item_details, bom_no, company, include_non_stock_ite
 				if d.qty > 0:
 					get_subitems(doc, data, item_details, d.default_bom, company,
 						include_non_stock_items, include_subcontracted_items, d.qty)
-		item_details['sales_order'] = sales_order if sales_order else ""
+		if sales_order:
+			item_details['sales_order'] = sales_order
 	return item_details
 
 def get_material_request_items(row, sales_order,

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -564,8 +564,7 @@ def get_subitems(doc, data, item_details, bom_no, company, include_non_stock_ite
 				if d.qty > 0:
 					get_subitems(doc, data, item_details, d.default_bom, company,
 						include_non_stock_items, include_subcontracted_items, d.qty)
-		if sales_order:
-			item_details['sales_order'] = sales_order
+		item_details['sales_order'] = sales_order if sales_order else ""
 	return item_details
 
 def get_material_request_items(row, sales_order,

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -564,7 +564,8 @@ def get_subitems(doc, data, item_details, bom_no, company, include_non_stock_ite
 				if d.qty > 0:
 					get_subitems(doc, data, item_details, d.default_bom, company,
 						include_non_stock_items, include_subcontracted_items, d.qty)
-		item_details['sales_order'] = sales_order
+		if sales_order:
+			item_details['sales_order'] = sales_order
 	return item_details
 
 def get_material_request_items(row, sales_order,

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -423,7 +423,7 @@ class TestSalesOrder(unittest.TestCase):
 
 		test_user = frappe.get_doc("User", "test@example.com")
 		test_user.add_roles("Sales User", "Stock User")
-		test_user.remove_roles("Sales Manager")
+		test_user.remove_roles("Sales Manager", "System Manager")
 
 		test_user_2 = frappe.get_doc("User", "test2@example.com")
 		test_user_2.add_roles("Sales User", "Stock User")

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -47,7 +47,7 @@ class TestPickList(unittest.TestCase):
 		pick_list.set_item_locations()
 
 		self.assertEqual(pick_list.locations[0].item_code, '_Test Item Home Desktop 100')
-		self.assertEqual(pick_list.locations[0].warehouse, '_Test Warehouse 1 - _TC')
+		self.assertEqual(pick_list.locations[0].warehouse, '_Test Warehouse - _TC')
 		self.assertEqual(pick_list.locations[0].qty, 5)
 
 	def test_pick_list_splits_row_according_to_warhouse_availability(self):
@@ -187,12 +187,12 @@ class TestPickList(unittest.TestCase):
 		pick_list.set_item_locations()
 
 		self.assertEqual(pick_list.locations[0].item_code, '_Test Item Home Desktop 100')
-		self.assertEqual(pick_list.locations[0].warehouse, '_Test Warehouse 1 - _TC')
+		self.assertEqual(pick_list.locations[0].warehouse, '_Test Warehouse - _TC')
 		self.assertEqual(pick_list.locations[0].qty, 5)
 		self.assertEqual(pick_list.locations[0].sales_order_item, '_T-Sales Order-1_item')
 
 		self.assertEqual(pick_list.locations[1].item_code, '_Test Item Home Desktop 100')
-		self.assertEqual(pick_list.locations[1].warehouse, '_Test Warehouse 1 - _TC')
+		self.assertEqual(pick_list.locations[1].warehouse, '_Test Warehouse - _TC')
 		self.assertEqual(pick_list.locations[1].qty, 5)
 		self.assertEqual(pick_list.locations[1].sales_order_item, sales_order.items[0].name)
 

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -431,7 +431,6 @@ def update_args_for_serial_no(serial_no_doc, serial_no, args, is_new=False):
 		"via_stock_ledger": args.get("via_stock_ledger") or True,
 		"supplier": args.get("supplier"),
 		"location": args.get("location"),
-		"sales_order": frappe.db.get_value(args.get("voucher_type"), args.get("voucher_no"), "sales_order_no"),
 		"warehouse": (args.get("warehouse")
 			if args.get("actual_qty", 0) > 0 else None)
 	})

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -431,6 +431,7 @@ def update_args_for_serial_no(serial_no_doc, serial_no, args, is_new=False):
 		"via_stock_ledger": args.get("via_stock_ledger") or True,
 		"supplier": args.get("supplier"),
 		"location": args.get("location"),
+		"sales_order": frappe.db.get_value(args.get("voucher_type"), args.get("voucher_no"), "sales_order_no"),
 		"warehouse": (args.get("warehouse")
 			if args.get("actual_qty", 0) > 0 else None)
 	})


### PR DESCRIPTION
**Task ID**:  https://bloomstack.com/desk#Form/Task/TASK-2021-00345
 
- [x] Fixes

**Description**: 

1. In Sales Order Test cases there is Permission error validation
2. In Sales Order In items Details object set None value.
3. In Pick List Test cases warehouses name error.
4. In Sales Invoice Test Cases Some are Item Code related Issue.
5.  In AccountingDimension  Test Cases ValidationError Raise error.
6. In Invoice Discounting Test Cases Some are Item Code related Issue.

**Tested**: YES 

List of Test cases Solved:
```
- test_request_for_raw_materials (erpnext.selling.doctype.sales_order.test_sales_order.TestSalesOrder)
- test_warehouse_user (erpnext.selling.doctype.sales_order.test_sales_order.TestSalesOrder)
-  test_update_child_qty_rate_perm (erpnext.selling.doctype.sales_order.test_sales_order.TestSalesOrder)
- test_serial_no_based_delivery (erpnext.selling.doctype.sales_order.test_sales_order.TestSalesOrder)
- test_pick_list_for_items_from_multiple_sales_orders (erpnext.stock.doctype.pick_list.test_pick_list.TestPickList)
- test_pick_list_picks_warehouse_for_each_item (erpnext.stock.doctype.pick_list.test_pick_list.TestPickList)
- test_pick_list_shows_serial_no_for_serialized_item (erpnext.stock.doctype.pick_list.test_pick_list.TestPickList)
- test_pp_to_mr_customer_provided (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan)
- test_production_plan (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan)
- test_production_plan_for_existing_ordered_qty (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan) 
- test_production_plan_with_non_stock_item (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan)
- test_production_plan_without_multi_level (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan)
- test_production_plan_without_multi_level_for_existing_ordered_qty (erpnext.manufacturing.doctype.production_plan.test_production_plan.TestProductionPlan)
- test_create_so_with_margin (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_return_sales_invoice (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice) 
- test_rounding_adjustment_2 (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_for_disable_allow_cost_center_in_entry_of_bs_account (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_for_enable_allow_cost_center_in_entry_of_bs_account (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_gl_entry_with_perpetual_inventory_no_item_code (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_gl_entry_with_perpetual_inventory_non_stock_item (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_gl_entry_without_perpetual_inventory (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_with_advance (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_serialized (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_serialized_cancel (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_sales_invoice_with_discount_and_inclusive_tax (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_serial_numbers_against_delivery_note (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice)
- test_make_payment_before_after_period (erpnext.accounts.doctype.invoice_discounting.test_invoice_discounting.TestInvoiceDiscounting)
- test_make_payment_before_loan_period (erpnext.accounts.doctype.invoice_discounting.test_invoice_discounting.TestInvoiceDiscounting)
- test_mandatory (erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension.TestAccountingDimension)
```
**Trackback/Screenshot:**: 
        **Sales Order  Test**
<img width="1440" alt="Screenshot 2021-10-01 at 9 55 13 AM" src="https://user-images.githubusercontent.com/15030453/135574425-7d8a95b6-9144-4478-8620-ee6d0e088eb4.png">


<img width="1423" alt="Screenshot 2021-10-01 at 11 47 23 AM" src="https://user-images.githubusercontent.com/15030453/135574464-78f408f4-8ec5-43b8-96a7-6e4329b967fd.png">

        **Pick List  Test**
<img width="1440" alt="Screenshot 2021-10-01 at 9 54 54 AM" src="https://user-images.githubusercontent.com/15030453/135574482-20a08ac9-975e-44b2-8c62-c760b91ec089.png">

 **Sales Invoice  Test Cases**

1. <img width="1440" alt="SI-01" src="https://user-images.githubusercontent.com/15030453/136326160-d202bd32-14ab-4c32-854b-32950d678dad.png">

2. <img width="1440" alt="SI-02" src="https://user-images.githubusercontent.com/15030453/136326252-caf70165-f95f-4c16-bd96-6fa608e119bf.png">

3. <img width="1440" alt="SI-03" src="https://user-images.githubusercontent.com/15030453/136326330-7c19b684-cc5f-4a39-826a-132a32123712.png">

4. <img width="1440" alt="SI-04" src="https://user-images.githubusercontent.com/15030453/136326350-11ccd978-a54b-4236-b1a7-07afe20897d6.png">

5. <img width="1416" alt="SI-05" src="https://user-images.githubusercontent.com/15030453/136326385-3d17667e-34bc-4657-9419-2e1f98a70c62.png">

6. <img width="1375" alt="SI-06" src="https://user-images.githubusercontent.com/15030453/136326443-e70635a5-cb31-4700-ae0b-675901cb4dd8.png">
 
7. <img width="1278" alt="SI-07" src="https://user-images.githubusercontent.com/15030453/136326502-35fc9265-47a7-4221-95de-1f289ff7eac0.png">

8. <img width="1438" alt="SI-08" src="https://user-images.githubusercontent.com/15030453/136326558-b3246cf0-cf73-4909-8d21-dabbb908b6c4.png">

 **Invoice Discounting**

<img width="1440" alt="ID-1" src="https://user-images.githubusercontent.com/15030453/136509935-873e0373-f6d6-40dc-b6f2-0f92dc58045d.png">

 **Accounting Dimension**

<img width="1440" alt="AD-1" src="https://user-images.githubusercontent.com/15030453/136509994-a4c1489c-04f7-49d4-a01f-9b23fd6a7949.png">


